### PR TITLE
Change config file default path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,18 +91,18 @@ lint:
 
 install: all
 	mkdir -p $(DESTDIR)/$(LIB_PREFIX)/$(PLUGIN_DIR)
-	mkdir -p $(DESTDIR)/etc/openvpn/
+	mkdir -p $(DESTDIR)/etc/okta-auth-validator/
 	mkdir -p $(DESTDIR)/usr/include
 	mkdir -p $(DESTDIR)/usr/bin
 	$(INSTALL) -m755 $(BUILDDIR)/okta-auth-validator $(DESTDIR)/usr/bin/
 	$(INSTALL) -m644 $(BUILDDIR)/libokta-auth-validator.so $(DESTDIR)/$(LIB_PREFIX)/
 	$(INSTALL) -m644 $(BUILDDIR)/libokta-auth-validator.h $(DESTDIR)/usr/include/
 	$(INSTALL) -m644 $(BUILDDIR)/openvpn-plugin-okta.so $(DESTDIR)/$(LIB_PREFIX)/$(PLUGIN_DIR)/
-	if [ ! -f $(DESTDIR)/etc/openvpn/okta_pinset.cfg ]; then \
-		$(INSTALL) -m644 okta_pinset.cfg $(DESTDIR)/etc/openvpn/okta_pinset.cfg; \
+	if [ ! -f $(DESTDIR)/etc/okta-auth-validator/okta_pinset.cfg ]; then \
+		$(INSTALL) -m644 okta_pinset.cfg $(DESTDIR)/etc/okta-auth-validator/okta_pinset.cfg; \
 	fi
-	if [ ! -f $(DESTDIR)/etc/openvpn/okta_openvpn.ini ]; then \
-		$(INSTALL) -m640 okta_openvpn.ini.inc $(DESTDIR)/etc/openvpn/okta_openvpn.ini; \
+	if [ ! -f $(DESTDIR)/etc/okta-auth-validator/okta_openvpn.ini ]; then \
+		$(INSTALL) -m640 okta_openvpn.ini.inc $(DESTDIR)/etc/okta-auth-validator/okta_openvpn.ini; \
 	fi
 
 clean:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You have three options to install the Okta OpenVPN plugin:
 
 ### 1.  For default setups, use `sudo make install` to run the install for you.
 
-If you have a default OpenVPN setup, where plugins are stored in `/usr/lib/openvpn/plugins` and configuration files are stored in `/etc/openvpn`, then you can use the `make install` command to install the Okta OpenVPN plugin:
+If you have a default OpenVPN setup, where plugins are stored in `/usr/lib/openvpn/plugins` and configuration files are stored in `/etc/okta-auth-validator`, then you can use the `make install` command to install the Okta OpenVPN plugin:
 
 ```shell
 $ sudo make install
@@ -150,7 +150,7 @@ The Okta OpenVPN plugin is configured via the `okta\_openvpn.ini` file. You **mu
 If you installed the Okta OpenVPN plugin to the default location, run this command to edit your configuration file.
 
 ```shell
-$ sudo $EDITOR /etc/openvpn/okta_openvpn.ini
+$ sudo $EDITOR /etc/okta-auth-validator/okta_openvpn.ini
 ```
 > :warning: As this file contains your Okta token, please ensure it has limited permissions (should only be readable by root or the user running OpenVPN) !
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+openvpn-auth-okta (2.4.1) stable; urgency=medium
+
+  [ Jeremy JACQUE ]
+  * chore: renamed repo and packages
+  * chore(github): add code owners and PR template
+  * chore(Makefile): change config files location
+  * chore(doc): change config files location
+  * chore(dist): change config files location
+  * chore(validator): change default config files location
+
+ -- Jeremy Jacque <jeremy.jacque@algolia.com>  Thu, 19 Oct 2023 14:19:03 +0000
+
 openvpn-auth-okta (2.4.0) stable; urgency=medium
 
   [ Jeremy JACQUE ]

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -3,8 +3,8 @@ DEBTRANSFORM-RELEASE: 1
 Source: openvpn-auth-okta
 Binary: openvpn-auth-okta
 Architecture: any
-Version: 2.4.0
-DEBTRANSFORM-TAR: openvpn-auth-okta-2.4.0.tar.xz
+Version: 2.4.1
+DEBTRANSFORM-TAR: openvpn-auth-okta-2.4.1.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -57,10 +57,10 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 %files
 %dir %{_libdir}/openvpn
 %dir %{plugin_dir}/
-%dir /etc/openvpn/
+%dir /etc/okta-auth-validator/
 %attr(0644,root,root) %{plugin_dir}/openvpn-plugin-okta.so
-%attr(0644,root,root) %config(noreplace) /etc/openvpn/okta_pinset.cfg
-%attr(0640,root,root) %config(noreplace) /etc/openvpn/okta_openvpn.ini
+%attr(0644,root,root) %config(noreplace) /etc/okta-auth-validator/okta_pinset.cfg
+%attr(0640,root,root) %config(noreplace) /etc/okta-auth-validator/okta_openvpn.ini
 
 %files -n okta-auth-validator
 %attr(0755,root,root) /usr/bin/okta-auth-validator

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -1,5 +1,5 @@
 Name: openvpn-auth-okta
-Version: 2.4.0
+Version: 2.4.1
 Release: 1%{?dist}
 Summary: Go programming language
 Group: Productivity/Networking/Security
@@ -73,6 +73,14 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 
 
 %changelog
+* Thu Oct 19 2023 vagrant <jeremy.jacque@algolia.com> 2.4.1-1
+- chore: renamed repo and packages
+- chore(github): add code owners and PR template
+- chore(Makefile): change config files location
+- chore(doc): change config files location
+- chore(dist): change config files location
+- chore(validator): change default config files location
+
 * Thu Oct 19 2023 vagrant <jeremy.jacque@algolia.com> 2.4.0-1
 - chore(debian): split package
 - chore(dist): split package

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -14,12 +14,14 @@ import (
 )
 
 var (
-  cfgDefaultPaths = [3]string{
+  cfgDefaultPaths = [4]string{
+    "/etc/okta-auth-validator/okta_openvpn.ini",
     "/etc/openvpn/okta_openvpn.ini",
     "/etc/okta_openvpn.ini",
     "okta_openvpn.ini",
   }
-  pinsetDefaultPaths = [3]string{
+  pinsetDefaultPaths = [4]string{
+    "/etc/okta-auth-validator/okta_pinset.cfg",
     "/etc/openvpn/okta_pinset.cfg",
     "/etc/okta_pinset.cfg",
     "okta_pinset.cfg",


### PR DESCRIPTION
### What does this PR do?

Change the default config files path from `/etc/openvpn` to `/etc/okta-auth-validator`:

- chore(Makefile): change config files location
- chore(doc): change config files location
- chore(dist): change config files location
- chore(validator): change default config files location
- chore(dist): Update changelog for 2.4.1 release
- chore(debian): Update changelog for 2.4.1 release

### Motivation

This software has been originally created to integrate Okta auth in OpenVPN, but can be used completely separately, so there is no reason that its config files are stored in `/etc/openvpn` anymore.

### More

- [ ] Added/updated tests
- [x] Added/updated documentation