### PR TITLE
Rename pplugin file name to be aligned with other openVPN plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,8 @@
 okta_openvpn
 venv/
 .DS_Store
-cover/
-.coverage
+build/
 okta_openvpn.ini
-cover.out
-cover-badge.out
-coverage.html
 .dccache
 
 # Temporary testing files

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOFLAGS := -buildmode=pie -a $(GOLDFLAGS)
 LIBOKTA_LDFLAGS := -ldflags '-extldflags -Wl,-soname,libokta-auth-validator.so'
 LIBOKTA_FLAGS := -buildmode=c-shared $(LIBOKTA_LDFLAGS)
 
-LIBRARIES := $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-okta.so
+LIBRARIES := $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-auth-okta.so
 
 all: $(BUILDDIR)/okta-auth-validator plugin
 
@@ -39,9 +39,9 @@ binary: $(BUILDDIR)/okta-auth-validator
 $(BUILDDIR)/okta-auth-validator: cmd/okta-auth-validator/main.go | $(BUILDDIR)
 	CGO_ENABLED=0 go build $(GOFLAGS) -o $(BUILDDIR)/okta-auth-validator cmd/okta-auth-validator/main.go
 
-# Build the openvpn-plugin-okta plugin (linked against the Go c-shared lib)
-$(BUILDDIR)/openvpn-plugin-okta.so: $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-okta.o openvpn-plugin.h
-	$(CC)  $(LDFLAGS) -Wl,-soname,openvpn-plugin-okta.so -o $(BUILDDIR)/openvpn-plugin-okta.so $(BUILDDIR)/openvpn-plugin-okta.o
+# Build the openvpn-plugin-auth-okta plugin (linked against the Go c-shared lib)
+$(BUILDDIR)/openvpn-plugin-auth-okta.so: $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-auth-okta.o openvpn-plugin.h
+	$(CC)  $(LDFLAGS) -Wl,-soname,openvpn-plugin-auth-okta.so -o $(BUILDDIR)/openvpn-plugin-auth-okta.so $(BUILDDIR)/openvpn-plugin-auth-okta.o
 
 # Build the okta-auth-validator shared lib (Golang c-shared)
 $(BUILDDIR)/libokta-auth-validator.so: lib/libokta-auth-validator.go | $(BUILDDIR)
@@ -97,7 +97,7 @@ install: all
 	$(INSTALL) -m755 $(BUILDDIR)/okta-auth-validator $(DESTDIR)/usr/bin/
 	$(INSTALL) -m644 $(BUILDDIR)/libokta-auth-validator.so $(DESTDIR)/$(LIB_PREFIX)/
 	$(INSTALL) -m644 $(BUILDDIR)/libokta-auth-validator.h $(DESTDIR)/usr/include/
-	$(INSTALL) -m644 $(BUILDDIR)/openvpn-plugin-okta.so $(DESTDIR)/$(LIB_PREFIX)/$(PLUGIN_DIR)/
+	$(INSTALL) -m644 $(BUILDDIR)/openvpn-plugin-auth-okta.so $(DESTDIR)/$(LIB_PREFIX)/$(PLUGIN_DIR)/
 	if [ ! -f $(DESTDIR)/etc/okta-auth-validator/okta_pinset.cfg ]; then \
 		$(INSTALL) -m644 okta_pinset.cfg $(DESTDIR)/etc/okta-auth-validator/okta_pinset.cfg; \
 	fi

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ If you have a custom setup, follow the instructions below to install the C plugi
 
 #### Manually installing the C Plugin
 
-To manually install the C plugin, copy the `build/openvpn-plugin-okta.so` file to the location where your OpenVPN plugins are stored and the `libokta-auth-validator.so`file to your system libdir.
+To manually install the C plugin, copy the `build/openvpn-plugin-auth-okta.so` file to the location where your OpenVPN plugins are stored and the `libokta-auth-validator.so`file to your system libdir.
 
 
 #### Manually installing the Golang binary
@@ -162,7 +162,7 @@ See [okta_openvpn.ini](https://github.com/algolia/openvpn-auth-okta/blob/v2/okta
 Set up OpenVPN to call the Okta plugin by adding the following lines to your OpenVPN `server.conf` configuration file:
 
 ```ini
-plugin openvpn-plugin-okta.so
+plugin openvpn-plugin-auth-okta.so
 tmp-dir "/etc/openvpn/tmp"
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Thanks to the [OpenSUSE Build Service](https://build.opensuse.org/) packages are
 ```shell
 # supports Debian 11, 12 and Ubuntu 20.04, 22.04, 23.04, 23.10
 . /etc/os-release
-if [ "${Name}" = "Ubuntu" ]
+if [ "${NAME}" = "Ubuntu" ]
 then
   DIST="xUbuntu"
 else
@@ -179,6 +179,13 @@ Set up OpenVPN to call the Okta Golang binary by adding the following lines to y
 auth-user-pass-verify /usr/bin/okta-auth-validator via-file
 tmp-dir "/etc/openvpn/tmp"
 ```
+> :exclamation: it is strongly advised when using the via file method, that the tmp-dir is located on a tmpfs filesystem (so that the user's credentials never reach the disk). Systemd can help for that:
+
+```shell
+VUSER=openvpn
+echo "d /run/openvpn/tmp 1750 ${VUSER} root" | sudo tee /etc/tmpfiles.d/openvpn-tmp.conf
+sudo systemd-tmpfiles  --create /etc/tmpfiles.d/openvpn-tmp.conf
+```
 
 ```ini
 # "via-env" method
@@ -188,7 +195,7 @@ tmp-dir "/etc/openvpn/tmp"
 
 Please check the OpenVPN [manual](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-0/#options) for security considerations regarding this mode.
 
-The default location for OpenVPN configuration files is `/etc/openvpn/server.conf`
+The default location for OpenVPN configuration files is usually `/etc/openvpn/server.conf`
 
 
 # Useful links

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+openvpn-auth-okta (2.4.3) stable; urgency=medium
+
+  [ Jeremy JACQUE ]
+  * chore: change plugin file name to be aligned with other OpenVPN plugins
+  * chore(doc): fix typo in install section and add info about OpenVPN tmp dir
+  * chore(plugin): rename source according to new plugin file name
+  * chore(doc): update with new plugin name
+  * chore(git): now all produced files are in a dedicated dir, so ignore this dir
+
+ -- Jeremy Jacque <jeremy.jacque@algolia.com>  Fri, 20 Oct 2023 07:36:46 +0000
+
 openvpn-auth-okta (2.4.2) stable; urgency=medium
 
   [ Jeremy JACQUE ]

--- a/debian/openvpn-auth-okta.install
+++ b/debian/openvpn-auth-okta.install
@@ -1,1 +1,1 @@
-usr/bin/okta-auth-validator
+usr/lib/*/openvpn/plugins/openvpn-plugin-auth-okta.so

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -3,8 +3,8 @@ DEBTRANSFORM-RELEASE: 1
 Source: openvpn-auth-okta
 Binary: openvpn-auth-okta
 Architecture: any
-Version: 2.4.2
-DEBTRANSFORM-TAR: openvpn-auth-okta-2.4.2.tar.xz
+Version: 2.4.3
+DEBTRANSFORM-TAR: openvpn-auth-okta-2.4.3.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -1,5 +1,5 @@
 Name: openvpn-auth-okta
-Version: 2.4.2
+Version: 2.4.3
 Release: 1%{?dist}
 Summary: Go programming language
 Group: Productivity/Networking/Security
@@ -73,6 +73,13 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 
 
 %changelog
+* Fri Oct 20 2023 Jeremy Jacque <jeremy.jacque@algolia.com> 2.4.3-1
+- chore: change plugin file name to be aligned with other OpenVPN plugins
+- chore(doc): fix typo in install section and add info about OpenVPN tmp dir
+- chore(plugin): rename source according to new plugin file name
+- chore(doc): update with new plugin name
+- chore(git): now all produced files are in a dedicated dir, so ignore this dir
+
 * Fri Oct 20 2023 Jeremy Jacque <jeremy.jacque@algolia.com> 2.4.2-1
 - chore(validator): refacto to remove useless functions and better err control on Authenticate
 - chore(cmd/okta-auth-validator): adapt to new Authenticate return type

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -58,7 +58,7 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 %dir %{_libdir}/openvpn
 %dir %{plugin_dir}/
 %dir /etc/okta-auth-validator/
-%attr(0644,root,root) %{plugin_dir}/openvpn-plugin-okta.so
+%attr(0644,root,root) %{plugin_dir}/openvpn-plugin-auth-okta.so
 %attr(0644,root,root) %config(noreplace) /etc/okta-auth-validator/okta_pinset.cfg
 %attr(0640,root,root) %config(noreplace) /etc/okta-auth-validator/okta_openvpn.ini
 

--- a/openvpn-plugin-auth-okta.c
+++ b/openvpn-plugin-auth-okta.c
@@ -58,7 +58,7 @@ static plugin_log_t plugin_log = NULL;
 struct plugin_context {};
 
 /* module name for plugin_log() */
-static char *MODULE = "openvpn-plugin-okta";
+static char *MODULE = "openvpn-plugin-auth-okta";
 
 /*
  * Given an environmental variable name, search


### PR DESCRIPTION
- chore: change plugin file name to be aligned with other OpenVPN plugins
- chore(doc): fix typo in install section and add info about OpenVPN tmp dir
- chore(plugin): rename source according to new plugin file name
- chore(doc): update with new plugin name
- chore(git): now all proced files are in a dedicated dir, so ignore this dir

### What does this PR do?

Rename plugin file, its source, packaging files and the related docs

### Motivation

Be aligned with other OpenVPN plugins (such as the auth-pam plugin)


### More

- [X] Added/updated documentation
