### PR TITLE
Fix packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,19 +9,19 @@ Homepage: https://github.com/algolia/openvpn-auth-okta
 Package: openvpn-auth-okta
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}, libokta-auth-validator (>= ${source:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}, libokta-auth-validator (= ${source:Version}), okta-auth-validator-common (= ${source:Version})
 Description: This is a plugin for OpenVPN (Community Edition) that authenticates users directly against Okta, with support for MFA.
 
 Package: okta-auth-validator
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}, libokta-auth-validator (>= ${source:Version})
+Depends: ${misc:Depends}, ${shlibs:Depends}, libokta-auth-validator (= ${source:Version}), okta-auth-validator-common (= ${source:Version})
 Description: This is a command line tool that authenticates users directly against Okta, with support for MFA.
 
 Package: libokta-auth-validator
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}, okta-auth-validator-common (= ${source:Version})
 Suggests: libokta-auth-validator-dev
 Description: Shared library that allows to authenticates user directly against Okta, with support for MFA.
 
@@ -30,3 +30,10 @@ Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Development files for libokta-auth-validator.
+
+Package: okta-auth-validator-common
+Architecture: all
+Pre-Depends: ${misc:Pre-Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: Config files for okta-auth-validator.
+

--- a/debian/okta-auth-validator-common.install
+++ b/debian/okta-auth-validator-common.install
@@ -1,0 +1,2 @@
+etc/okta-auth-validator/okta_pinset.cfg
+etc/okta-auth-validator/okta_openvpn.ini

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -13,6 +13,7 @@ BuildRequires: golang-1.21
 BuildRequires: gcc
 BuildRequires: make
 Requires: libokta-auth-validator = %{version}
+Requires: okta-auth-validator-common = %{version}
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-build
 
@@ -24,6 +25,7 @@ This is a plugin for OpenVPN (Community Edition) that authenticates users direct
 
 %package -n okta-auth-validator
 Summary: Command line tool to authenticate against Okta.
+Requires: okta-auth-validator-common = %{version}
 
 %description -n okta-auth-validator
 This is a command line tool that authenticates users directly against Okta, with support for MFA.
@@ -31,6 +33,7 @@ This is a command line tool that authenticates users directly against Okta, with
 
 %package -n libokta-auth-validator
 Summary: Shared library to authenticate against Okta.
+Requires: okta-auth-validator-common = %{version}
 
 %description -n libokta-auth-validator
 Shared library that allows to authenticates user directly against Okta, with support for MFA.
@@ -39,6 +42,10 @@ Shared library that allows to authenticates user directly against Okta, with sup
 %package -n libokta-auth-validator-devel
 Summary: Development files for libokta-auth-validator.
 Requires: libokta-auth-validator = %{version}
+
+%package -n okta-auth-validator-common
+Summary: Config files for libokta-auth-validator.
+
 
 %description -n libokta-auth-validator-devel
 Development files for libokta-auth-validator, a shared library that allows to authenticates user directly against Okta, with support for MFA.
@@ -57,8 +64,10 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 %files
 %dir %{_libdir}/openvpn
 %dir %{plugin_dir}/
-%dir /etc/okta-auth-validator/
 %attr(0644,root,root) %{plugin_dir}/openvpn-plugin-auth-okta.so
+
+%files -n okta-auth-validator-common
+%dir /etc/okta-auth-validator/
 %attr(0644,root,root) %config(noreplace) /etc/okta-auth-validator/okta_pinset.cfg
 %attr(0640,root,root) %config(noreplace) /etc/okta-auth-validator/okta_openvpn.ini
 

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 # Update all dist, debian files when bumping version
+#
+# Needs https://github.com/agx/git-buildpackage
 
 version=$1
 
@@ -19,6 +21,9 @@ git add dist/openvpn-auth-okta.spec
 git commit -m "chore(dist): Update changelog for ${version} release"
 
 sed -i'' -e "s/^\(DEBTRANSFORM-TAR: openvpn-auth-okta-\).*\(\.tar\.xz\)$/\1${version}\2/" dist/openvpn-auth-okta.dsc
+sed -i'' -e "s/^\(Version: \).*/\1${version}/" dist/openvpn-auth-okta.dsc
+git add dist/openvpn-auth-okta.dsc
+
 gbp dch --debian-branch="${branch}" \
   -c --commit-msg="chore(debian): Update changelog for %(version)s release" \
   --release \
@@ -27,7 +32,5 @@ gbp dch --debian-branch="${branch}" \
   --spawn-editor=no \
   --debian-tag="v%(version)s" \
   -N "${version}"
-
-sed -i'' -e "s/^\(Version: \).*/\1${version}/" dist/openvpn-auth-okta.dsc
 
 git tag -f -a "v${version}" -m "v${version}"


### PR DESCRIPTION
### What does this PR do?

Split packages to have a config dedicated one


### Motivation

On Debian family, config files were not installed ...
On RPM and DEB install, ensure config files are deployed whether you install the OpenVPN plugin, the lib or the command line tool.


### More

- [ ] Added/updated tests
- [ ] Added/updated documentation
