### PR TITLE
Fix gofmt, refacto oktaApiAuth.Auth to reduce complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/algolia/openvpn-auth-okta.svg)
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/algolia/openvpn-auth-okta.v2.svg)](https://pkg.go.dev/gopkg.in/algolia/openvpn-auth-okta.v2)
 ![CI status](https://circleci.com/gh/algolia/openvpn-auth-okta/tree/v2.svg?style=shield)
-![Coverage](https://img.shields.io/badge/Coverage-95.9%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-96.6%25-brightgreen)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/algolia/openvpn-auth-okta.v2)](https://goreportcard.com/report/gopkg.in/algolia/openvpn-auth-okta.v2)
 
 # Introduction

--- a/cmd/okta-auth-validator/main.go
+++ b/cmd/okta-auth-validator/main.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/validator"
 	log "github.com/sirupsen/logrus"
 	"github.com/t-tomalak/logrus-easy-formatter"
+	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/validator"
 )
 
 var (
@@ -24,7 +24,7 @@ func main() {
 	args := flag.Args()
 	log.SetFormatter(&easy.Formatter{
 		TimestampFormat: time.ANSIC,
-		LogFormat: "%time% [okta-auth-validator](%lvl%): %msg%\n",
+		LogFormat:       "%time% [okta-auth-validator](%lvl%): %msg%\n",
 	})
 	if *debug {
 		log.SetLevel(log.DebugLevel)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+openvpn-auth-okta (2.5.6) stable; urgency=medium
+
+  [ Jeremy JACQUE ]
+  * style: gofmt some source files
+  * refacto(oktaApiAuth): reduce gocyclo score of Auth to an acceptable score
+  * chore(oktaApiAuth): homogenize some Auth logs
+  * chore(oktaApiAuth/test): add a test for invalid preauth response
+  * chore(doc): update coverage badge
+
+ -- vagrant <jeremy.jacque@algolia.com>  Fri, 15 Dec 2023 12:50:53 +0000
+
 openvpn-auth-okta (2.5.5) stable; urgency=medium
 
   [ Jeremy JACQUE ]

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -3,8 +3,8 @@ DEBTRANSFORM-RELEASE: 1
 Source: openvpn-auth-okta
 Binary: openvpn-auth-okta
 Architecture: any
-Version: 2.5.5
-DEBTRANSFORM-TAR: openvpn-auth-okta-2.5.5.tar.xz
+Version: 2.5.6
+DEBTRANSFORM-TAR: openvpn-auth-okta-2.5.6.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -1,5 +1,5 @@
 Name: openvpn-auth-okta
-Version: 2.5.5
+Version: 2.5.6
 Release: 1%{?dist}
 Summary: Go programming language
 Group: Productivity/Networking/Security
@@ -84,6 +84,13 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 
 
 %changelog
+* Fri Dec 15 2023 vagrant <jeremy.jacque@algolia.com> 2.5.6-1
+- style: gofmt some source files
+- refacto(oktaApiAuth): reduce gocyclo score of Auth to an acceptable score
+- chore(oktaApiAuth): homogenize some Auth logs
+- chore(oktaApiAuth/test): add a test for invalid preauth response
+- chore(doc): update coverage badge
+
 * Thu Dec 14 2023 vagrant <jeremy.jacque@algolia.com> 2.5.5-1
 - chore(validator): add msg for setup failures
 - chore: use logrus to have a clean output

--- a/lib/libokta-auth-validator.go
+++ b/lib/libokta-auth-validator.go
@@ -5,9 +5,9 @@ import "C"
 import (
 	"time"
 
-	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/validator"
 	log "github.com/sirupsen/logrus"
 	"github.com/t-tomalak/logrus-easy-formatter"
+	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/validator"
 )
 
 type PluginEnv = validator.PluginEnv
@@ -16,7 +16,7 @@ type PluginEnv = validator.PluginEnv
 func OktaAuthValidator(ctrF *C.char, ip *C.char, cn *C.char, user *C.char, pass *C.char) {
 	log.SetFormatter(&easy.Formatter{
 		TimestampFormat: time.ANSIC,
-		LogFormat: "%time% [okta-auth-validator](%lvl%): %msg%\n",
+		LogFormat:       "%time% [okta-auth-validator](%lvl%): %msg%\n",
 	})
 
 	pluginEnv := &PluginEnv{

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -417,11 +417,11 @@ func (auth *OktaApiAuth) Auth() error {
 			return auth.validateMFA(preAuthRes, stateToken)
 
 		default:
-			log.Errorf("Unknown preauth status: %s", status)
+			log.Errorf("[%s] unknown preauth status: %s", auth.UserConfig.Username, status)
 			return errors.New("Unknown preauth status")
 		}
 	}
 
-	log.Warningf("[%s] User is not allowed to authenticate: %s", auth.UserConfig.Username, status)
-	return errors.New("Not allowed")
+	log.Errorf("[%s] missing preauth status", auth.UserConfig.Username)
+	return errors.New("Missing preauth status")
 }

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -153,10 +153,10 @@ func TestOktaReq(t *testing.T) {
 }
 
 type allowedGroupsTest struct {
-	testName string
-	requests []authRequest
+	testName      string
+	requests      []authRequest
 	allowedGroups string
-	err      error
+	err           error
 }
 
 func TestCheckAllowedGroups(t *testing.T) {

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -416,6 +416,23 @@ func TestAuth(t *testing.T) {
 		},
 
 		{
+			"PreAuth with invalid response (missing status) - failure",
+			false,
+			"",
+			[]authRequest{
+				{
+					"/api/v1/authn",
+					map[string]string{"username": username, "password": password},
+					http.StatusUnauthorized,
+					"preauth_missing_status.json",
+				},
+			},
+			false,
+			"",
+			fmt.Errorf("Missing preauth status"),
+		},
+
+		{
 			"PreAuth with locked out user - failure",
 			false,
 			"",

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -9,9 +9,9 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/oktaApiAuth"
 	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/testing/fixtures/oktaApi/preauth_missing_status.json
+++ b/testing/fixtures/oktaApi/preauth_missing_status.json
@@ -1,0 +1,51 @@
+{
+  "stateToken": "007ucIX7PATyn94hsHfOLVaXAmOBkKHWnOOLG43bsb",
+  "expiresAt": "2015-11-03T10:15:57.000Z",
+  "_embedded": {
+    "user": {
+      "id": "00ub0oNGTSWTBKOLGLNR",
+      "passwordChanged": "2015-09-08T20:14:45.000Z",
+      "profile": {
+        "login": "dade.murphy@example.com",
+        "firstName": "Dade",
+        "lastName": "Murphy",
+        "locale": "en_US",
+        "timeZone": "America/Los_Angeles"
+      }
+    },
+    "factors": [
+      {
+        "id": "opf3hkfocI4JTLAju0g4",
+        "factorType": "push",
+        "provider": "OKTA",
+        "profile": {
+          "credentialId": "dade.murphy@example.com",
+          "deviceType": "SmartPhone_IPhone",
+          "name": "Gibson",
+          "platform": "IOS",
+          "version": "9.0"
+        },
+        "_links": {
+          "verify": {
+            "href": "https://{yourOktaDomain}/api/v1/authn/factors/opf3hkfocI4JTLAju0g4/verify",
+            "hints": {
+              "allow": [
+                "POST"
+              ]
+            }
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "cancel": {
+      "href": "https://{yourOktaDomain}/api/v1/authn/cancel",
+      "hints": {
+        "allow": [
+          "POST"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?

- gofmt some source files
- refacto oktaApiAuth.Auth to reduce its complexity (splitted in multiple functions)
- add a test for invalid pre-authentication invalid Okta API response (missing status)
- bump version to 2.5.6


### Motivation

Clean code


### More

- [X] Added/updated tests
- [x] Added/updated documentation
