### PR TITLE
Refacto the Makefile, add missing dl* in C plugin code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,18 @@ LIB_PREFIX := /usr/lib
 PLUGIN_DIR := openvpn/plugins
 BUILDDIR := build
 
-GOLDFLAGS := -ldflags '-extldflags "-static"'
-GOFLAGS := -buildmode=pie -a $(GOLDFLAGS)
+GOLDFLAGS := -ldflags '-s -w -extldflags "-static"'
+GOFLAGS := -trimpath -buildmode=pie -a $(GOLDFLAGS)
 
 ifeq ($(UNAME_S),Linux)
-LIBOKTA_LDFLAGS := -ldflags '-extldflags -Wl,-soname,libokta-auth-validator.so'
+LIBOKTA_LDFLAGS := -ldflags '-s -w -extldflags -Wl,-soname,libokta-auth-validator.so'
 PLUGIN_LDFLAGS := -Wl,-soname,openvpn-plugin-auth-okta.so
 else
 # MacOs X
-LIBOKTA_LDFLAGS := -ldflags '-extldflags -Wl,-install_name,libokta-auth-validator.so'
+LIBOKTA_LDFLAGS := -ldflags '-s -w -extldflags -Wl,-install_name,libokta-auth-validator.so'
 PLUGIN_LDFLAGS := -Wl,-install_name,openvpn-plugin-auth-okta.so
 endif
-LIBOKTA_FLAGS := -buildmode=c-shared $(LIBOKTA_LDFLAGS)
+LIBOKTA_FLAGS := -trimpath -buildmode=c-shared $(LIBOKTA_LDFLAGS)
 
 
 PKGSRC := pkg/oktaApiAuth/oktaApiAuth.go pkg/utils/utils.go pkg/validator/validator.go

--- a/openvpn-plugin-auth-okta.c
+++ b/openvpn-plugin-auth-okta.c
@@ -211,6 +211,8 @@ deferred_auth_handler(const char *argv[], const char *envp[])
     plugin_log(PLOG_ERR|PLOG_ERRNO, MODULE, "Can not load libopenvpn-auth-okta.so");
     exit(127);
   }
+  // Clear any existing error
+  dlerror();
 
   void (*OktaAuthValidator)(char*, char*, char*, char*, char*) = dlsym(handle, "OktaAuthValidator");
   if ((error = dlerror()) != NULL)
@@ -221,6 +223,7 @@ deferred_auth_handler(const char *argv[], const char *envp[])
 
   // Call the Golang c-shared lib function
   (*OktaAuthValidator)((char*)ctrF, (char*)ip, (char*)cn, (char*)user, (char*)pass);
+  dlclose(handle);
   exit(0);
 }
 


### PR DESCRIPTION
### What does this PR do?

Add missing dlclose and dlerror in C plugin code (follow https://linux.die.net/man/3/dlopen example)
Minimize built file size (using -w -s ldflags) and trimpath
Clean unused Makefile variables and targets
