### PR TITLE
chore(debian): allow building with go 1.22

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: openvpn-auth-okta
 Section: net
 Priority: optional
 Maintainer: Jeremy Jacque <jeremy.jacque@algolia.com>
-Build-Depends: debhelper (>=10), make, gcc, golang-1.21
+Build-Depends: debhelper (>=10), make, gcc, golang-1.21 | golang-1.22
 Standards-Version: 0.1
 Homepage: https://github.com/algolia/openvpn-auth-okta
 

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -8,7 +8,7 @@ DEBTRANSFORM-TAR: openvpn-auth-okta-2.6.1.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10
-Build-Depends: debhelper, make, gcc, golang-1.21
+Build-Depends: debhelper, make, gcc, golang-1.21 | golang-1.22
 Package-List:
  openvpn-auth-okta deb base optional arch=any
  okta-auth-validator deb base optional arch=any


### PR DESCRIPTION
### What does this PR do?

Allow to build using Go 1.22
