### PR TITLE
Use sentinel errors and dedup some JSON processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ Choose the proper instructions for your Linux distribution [here](https://softwa
 
 #### Packages are available for
 
-- CentOS: `8`, `8 Stream`
-- Debian: `Bullseye` (11), `Bookworm` (12)
-- Fedora: `38`, `39`
-- openSUSE: `15.4`, `15.5`
-- Ubuntu: `Focal Fossa` (20.04), `Jammy Jellyfish` (22.04), `Lunar Lobster` (23.04), `Mantic Minotaur` (23.10)
+- CentOS (amd64, arm64): `8`, `8 Stream`
+- Fedora (amd64, arm64): `38`, `39`, `40`
+- Mageia (amd64, arm64): `8`, `9`
+- openSUSE (amd64, arm64, ppc64le): `15.4`, `15.5`, `15.5`
+- Debian (amd64, arm64): `Buster` (10), `Bullseye` (11), `Bookworm` (12)
+- Raspbian(arm64): `10`, `11`, `12`
+- Ubuntu (amd64, arm64): `Focal Fossa` (20.04), `Jammy Jellyfish` (22.04), `Lunar Lobster` (23.04), `Mantic Minotaur` (23.10), `Noble Numbat` (24.04)
 
 ### 2.  For default setups, use `sudo make install` to run the install for you
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/algolia/openvpn-auth-okta.svg)
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/algolia/openvpn-auth-okta.v2.svg)](https://pkg.go.dev/gopkg.in/algolia/openvpn-auth-okta.v2)
 ![CI status](https://circleci.com/gh/algolia/openvpn-auth-okta/tree/v2.svg?style=shield)
-![Coverage](https://img.shields.io/badge/Coverage-97.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-97.5%25-brightgreen)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/algolia/openvpn-auth-okta.v2)](https://goreportcard.com/report/gopkg.in/algolia/openvpn-auth-okta.v2)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/66b5143777dc441993ebfcea172e0626)](https://app.codacy.com/gh/algolia/openvpn-auth-okta/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -250,8 +250,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 				factor.Provider,
 				ftype,
 				errorSummary)
-			ferror := fmt.Sprintf("%s MFA failed", ftype)
-			return AuthResponse{}, errors.New(ferror)
+			return AuthResponse{}, fmt.Errorf("%s MFA failed", ftype)
 		}
 		log.Warn().Msgf("%s %s MFA authentication failed: %s",
 			factor.Provider,

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -199,7 +199,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 		if count == nbFactors-1 {
 			return AuthResponse{}, err
 		}
-		return AuthResponse{}, errors.New("continue")
+		return AuthResponse{}, errContinue
 	}
 
 	validate := validator.New(validator.WithRequiredStructEnabled())
@@ -233,7 +233,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 			factor.Provider,
 			ftype,
 			errorSummary)
-		return AuthResponse{}, errors.New("continue")
+		return AuthResponse{}, errContinue
 	}
 
 	var authRes AuthResponse
@@ -244,7 +244,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 			return AuthResponse{}, err
 		}
 		log.Warn().Msgf("Error unmarshaling Okta API response: %s", err)
-		return AuthResponse{}, errors.New("continue")
+		return AuthResponse{}, errContinue
 	}
 
 	err = validate.Struct(authRes)
@@ -254,7 +254,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 			return AuthResponse{}, err
 		}
 		log.Warn().Msgf("Error unmarshaling Okta API response: %s", err)
-		return AuthResponse{}, errors.New("continue")
+		return AuthResponse{}, errContinue
 	}
 	return authRes, nil
 }
@@ -273,7 +273,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 				return AuthResponse{}, errors.New("Push MFA timeout")
 			}
 			log.Warn().Msgf("%s push MFA timed out", factor.Provider)
-			return AuthResponse{}, errors.New("continue")
+			return AuthResponse{}, errContinue
 		}
 
 		time.Sleep(time.Duration(auth.ApiConfig.MFAPushDelaySeconds) * time.Second)
@@ -283,7 +283,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 			if count == nbFactors-1 {
 				return AuthResponse{}, err
 			}
-			return AuthResponse{}, errors.New("continue")
+			return AuthResponse{}, errContinue
 		}
 		if code != 200 && code != 202 {
 			if count == nbFactors-1 {
@@ -291,7 +291,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 				return AuthResponse{}, errors.New("Push MFA failed")
 			}
 			log.Warn().Msgf("%s push MFA invalid HTTP status code %d", factor.Provider, code)
-			return AuthResponse{}, errors.New("continue")
+			return AuthResponse{}, errContinue
 		}
 
 		authRes = AuthResponse{}
@@ -302,7 +302,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 				return AuthResponse{}, err
 			}
 			log.Warn().Msgf("Error unmarshaling Okta API response: %s", err)
-			return AuthResponse{}, errors.New("continue")
+			return AuthResponse{}, errContinue
 		}
 
 		err = validate.Struct(authRes)
@@ -312,7 +312,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 				return AuthResponse{}, err
 			}
 			log.Warn().Msgf("Error unmarshaling Okta API response: %s", err)
-			return AuthResponse{}, errors.New("continue")
+			return AuthResponse{}, errContinue
 		}
 	}
 	return authRes, nil

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -192,7 +192,7 @@ func (auth *OktaApiAuth) cancelAuth(stateToken string) {
 	_, _, _ = auth.oktaReq(http.MethodPost, "/authn/cancel", data)
 }
 
-func processJsonAnswer(apiRes []byte, count int, nbFactors int) (AuthResponse, error) {
+func processJSONAnswer(apiRes []byte, count int, nbFactors int) (AuthResponse, error) {
 	var authRes AuthResponse
 	err := json.Unmarshal(apiRes, &authRes)
 	if err != nil {
@@ -260,7 +260,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, count int, nbFactors
 		return AuthResponse{}, errContinue
 	}
 
-	return processJsonAnswer(apiRes, count, nbFactors)
+	return processJSONAnswer(apiRes, count, nbFactors)
 }
 
 // At first iteration and until the factorResult is different from WAITING
@@ -297,7 +297,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 			return AuthResponse{}, errContinue
 		}
 
-		authRes, err = processJsonAnswer(apiRes, count, nbFactors)
+		authRes, err = processJSONAnswer(apiRes, count, nbFactors)
 		if err != nil {
 			return authRes, err
 		}

--- a/pkg/oktaApiAuth/api_types.go
+++ b/pkg/oktaApiAuth/api_types.go
@@ -13,14 +13,14 @@ package oktaApiAuth
 import "errors"
 
 var (
-	errContinue = errors.New("continue")
-	errPushFailed = errors.New("Push MFA failed")
-	errTOTPFailed = errors.New("TOTP MFA failed")
-	errMFAUnavailable = errors.New("No MFA factor available")
-	errMFARequired = errors.New("MFA required")
-	errUserLocked = errors.New("User locked out")
+	errContinue        = errors.New("continue")
+	errPushFailed      = errors.New("Push MFA failed")
+	errTOTPFailed      = errors.New("TOTP MFA failed")
+	errMFAUnavailable  = errors.New("No MFA factor available")
+	errMFARequired     = errors.New("MFA required")
+	errUserLocked      = errors.New("User locked out")
 	errPasswordExpired = errors.New("User password expired")
-	errEnrollNeeded = errors.New("Needs to enroll")
+	errEnrollNeeded    = errors.New("Needs to enroll")
 )
 
 type ErrorResponse struct {

--- a/pkg/oktaApiAuth/api_types.go
+++ b/pkg/oktaApiAuth/api_types.go
@@ -10,6 +10,19 @@
 
 package oktaApiAuth
 
+import "errors"
+
+var (
+	errContinue = errors.New("continue")
+	errPushFailed = errors.New("Push MFA failed")
+	errTOTPFailed = errors.New("TOTP MFA failed")
+	errMFAUnavailable = errors.New("No MFA factor available")
+	errMFARequired = errors.New("MFA required")
+	errUserLocked = errors.New("User locked out")
+	errPasswordExpired = errors.New("User password expired")
+	errEnrollNeeded = errors.New("Needs to enroll")
+)
+
 type ErrorResponse struct {
 	Code    string        `json:"errorCode" validate:"required"`
 	Summary string        `json:"errorSummary" validate:"required"`

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -19,18 +19,6 @@ import (
 
 // Returns an initialized oktaApiAuth
 func New() *OktaApiAuth {
-	/*
-		utsname := unix.Utsname{}
-		_ = unix.Uname(&utsname)
-		userAgent := fmt.Sprintf("OktaOpenVPN/2.1.0 (%s %s) Go-http-client/%s",
-			utsname.Sysname,
-			utsname.Release,
-			runtime.Version()[2:])
-		fmt.Printf("agent: %s\n", userAgent)
-
-		using dynamic user agent does not work ....
-		so for now use a const var
-	*/
 
 	return &OktaApiAuth{
 		ApiConfig: &OktaAPIConfig{
@@ -42,7 +30,7 @@ func New() *OktaApiAuth {
 			TOTPFallbackToPush:  false,
 		},
 		UserConfig: &OktaUserConfig{},
-		userAgent:  userAgent,
+		userAgent:  "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/122.0 (OktaOpenVPN)",
 	}
 }
 

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -76,7 +76,9 @@ func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, 
 				}
 				continue
 			}
-			log.Debug().Msgf("%s Push MFA, waitForPush Result: %s", factor.Provider, authRes.Result)
+			if authRes.Result != "" {
+				log.Debug().Msgf("%s Push MFA, waitForPush Result: %s", factor.Provider, authRes.Result)
+			}
 		}
 
 		if authRes.Status == "SUCCESS" {

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -116,7 +116,7 @@ func commonAuthTest(authTests []authTest, t *testing.T) {
 			a := &OktaApiAuth{
 				ApiConfig:  apiCfg,
 				UserConfig: userCfg,
-				userAgent:  userAgent,
+				userAgent:  "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/122.0 (OktaOpenVPN)",
 			}
 			err := a.InitPool()
 			assert.Nil(t, err)

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -280,7 +280,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("User locked out"),
+			errUserLocked,
 		},
 
 		{
@@ -305,7 +305,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("User password expired"),
+			errPasswordExpired,
 		},
 
 		{
@@ -343,7 +343,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("MFA required"),
+			errMFARequired,
 		},
 
 		{
@@ -368,7 +368,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Needs to enroll"),
+			errEnrollNeeded,
 		},
 
 		{
@@ -442,7 +442,7 @@ func TestAuthMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("No MFA factor available"),
+			errMFAUnavailable,
 		},
 
 		{
@@ -467,7 +467,7 @@ func TestAuthMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("No MFA factor available"),
+			errMFAUnavailable,
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -534,7 +534,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 
 		{
@@ -571,7 +571,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 
 		{
@@ -620,7 +620,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 
 		{
@@ -657,7 +657,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 
 		{
@@ -787,7 +787,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 
 		{
@@ -1421,7 +1421,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("TOTP MFA failed"),
+			errTOTPFailed,
 		},
 
 		{
@@ -1452,7 +1452,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("TOTP MFA failed"),
+			errTOTPFailed,
 		},
 
 		{
@@ -1489,7 +1489,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("TOTP MFA failed"),
+			errTOTPFailed,
 		},
 
 		{
@@ -1691,7 +1691,7 @@ func TestAuthMFAFallback(t *testing.T) {
 			"",
 			1,
 			true,
-			fmt.Errorf("Push MFA failed"),
+			errPushFailed,
 		},
 	}
 	commonAuthTest(authTests, t)

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -52,7 +52,7 @@ type authTest struct {
 	allowedGroups string
 	pushRetries   int
 	fallback      bool
-	err           error
+	errMsg        string
 }
 
 /*
@@ -123,11 +123,13 @@ func commonAuthTest(authTests []authTest, t *testing.T) {
 
 			gock.InterceptClient(a.pool)
 			gock.DisableNetworking()
-			err2 := a.Auth()
-			if test.err == nil {
-				assert.Nil(t, err2)
+			err = a.Auth()
+			if test.errMsg == "" {
+				assert.NoError(t, err)
 			} else {
-				assert.Equal(t, test.err.Error(), err2.Error())
+				if assert.Error(t, err) {
+					assert.EqualError(t, err, test.errMsg)
+				}
 			}
 			if !test.unmatchedReq {
 				assert.False(t, gock.HasUnmatchedRequest())
@@ -161,7 +163,7 @@ func TestAuthGroups(t *testing.T) {
 			"test1, test2",
 			1,
 			false,
-			fmt.Errorf("Not mmember of an AllowedGroup"),
+			"Not mmember of an AllowedGroup",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -185,7 +187,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Post \"https://example.oktapreview.com/api/v1/authn\": gock: cannot match any request"),
+			"Post \"https://example.oktapreview.com/api/v1/authn\": gock: cannot match any request",
 		},
 
 		{
@@ -204,7 +206,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("pre-authentication rate limited"),
+			"pre-authentication rate limited",
 		},
 
 		{
@@ -223,7 +225,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("pre-authentication failed"),
+			"pre-authentication failed",
 		},
 
 		{
@@ -242,7 +244,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Key: 'PreAuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag"),
+			"Key: 'PreAuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag",
 		},
 
 		{
@@ -261,7 +263,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("invalid character '-' looking for beginning of object key string"),
+			"invalid character '-' looking for beginning of object key string",
 		},
 
 		{
@@ -280,7 +282,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			errUserLocked,
+			errUserLocked.Error(),
 		},
 
 		{
@@ -305,7 +307,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			errPasswordExpired,
+			errPasswordExpired.Error(),
 		},
 
 		{
@@ -324,7 +326,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -343,7 +345,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			errMFARequired,
+			errMFARequired.Error(),
 		},
 
 		{
@@ -368,7 +370,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			errEnrollNeeded,
+			errEnrollNeeded.Error(),
 		},
 
 		{
@@ -393,7 +395,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Unknown preauth status"),
+			"Unknown preauth status",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -417,7 +419,7 @@ func TestAuthMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Post \"https://example.oktapreview.com/api/v1/authn/factors/opf3hkfocI4JTLAju0g4/verify\": gock: cannot match any request"),
+			"Post \"https://example.oktapreview.com/api/v1/authn/factors/opf3hkfocI4JTLAju0g4/verify\": gock: cannot match any request",
 		},
 
 		{
@@ -442,7 +444,7 @@ func TestAuthMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errMFAUnavailable,
+			errMFAUnavailable.Error(),
 		},
 
 		{
@@ -467,7 +469,7 @@ func TestAuthMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errMFAUnavailable,
+			errMFAUnavailable.Error(),
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -503,7 +505,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -534,7 +536,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 
 		{
@@ -571,7 +573,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 
 		{
@@ -620,7 +622,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 
 		{
@@ -657,7 +659,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 
 		{
@@ -682,7 +684,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Post \"https://example.oktapreview.com/api/v1/authn/factors/opf3hkfocI4JTLAju0g4/verify\": gock: cannot match any request"),
+			"Post \"https://example.oktapreview.com/api/v1/authn/factors/opf3hkfocI4JTLAju0g4/verify\": gock: cannot match any request",
 		},
 
 		{
@@ -713,7 +715,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag"),
+			"Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag",
 		},
 
 		{
@@ -750,7 +752,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			fmt.Errorf("Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag"),
+			"Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag",
 		},
 
 		{
@@ -787,7 +789,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 
 		{
@@ -824,7 +826,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Push MFA timeout"),
+			"Push MFA timeout",
 		},
 
 		{
@@ -867,7 +869,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -904,7 +906,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -941,7 +943,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -984,7 +986,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1033,7 +1035,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			fmt.Errorf("Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag"),
+			"Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag",
 		},
 
 		{
@@ -1076,7 +1078,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1119,7 +1121,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1156,7 +1158,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1193,7 +1195,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1224,7 +1226,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1261,7 +1263,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			2,
 			false,
-			fmt.Errorf("invalid character '-' looking for beginning of object key string"),
+			"invalid character '-' looking for beginning of object key string",
 		},
 
 		{
@@ -1304,7 +1306,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -1334,7 +1336,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1365,7 +1367,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("invalid character '-' looking for beginning of object key string"),
+			"invalid character '-' looking for beginning of object key string",
 		},
 
 		{
@@ -1390,7 +1392,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1421,7 +1423,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errTOTPFailed,
+			errTOTPFailed.Error(),
 		},
 
 		{
@@ -1452,7 +1454,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errTOTPFailed,
+			errTOTPFailed.Error(),
 		},
 
 		{
@@ -1489,7 +1491,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			errTOTPFailed,
+			errTOTPFailed.Error(),
 		},
 
 		{
@@ -1520,7 +1522,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			fmt.Errorf("Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag"),
+			"Key: 'AuthResponse.Status' Error:Field validation for 'Status' failed on the 'required' tag",
 		},
 
 		{
@@ -1551,7 +1553,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1582,7 +1584,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 
 		{
@@ -1607,7 +1609,7 @@ func TestAuthTOTPMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			nil,
+			"",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -1649,7 +1651,7 @@ func TestAuthMFAFallback(t *testing.T) {
 			"",
 			1,
 			true,
-			nil,
+			"",
 		},
 		{
 			"Auth with invalid TOTP MFA, fallback to Push rejected - failure",
@@ -1691,7 +1693,7 @@ func TestAuthMFAFallback(t *testing.T) {
 			"",
 			1,
 			true,
-			errPushFailed,
+			errPushFailed.Error(),
 		},
 	}
 	commonAuthTest(authTests, t)

--- a/pkg/oktaApiAuth/types.go
+++ b/pkg/oktaApiAuth/types.go
@@ -12,8 +12,6 @@ package oktaApiAuth
 
 import "net/http"
 
-const userAgent string = "Mozilla/5.0 (Linux; x86_64) OktaOpenVPN/2.1.0"
-
 // Contains the configuration for the Okta API connection
 // Those configuration options are read from api.ini
 type OktaAPIConfig struct {

--- a/pkg/validator/config_test.go
+++ b/pkg/validator/config_test.go
@@ -11,7 +11,6 @@
 package validator
 
 import (
-	"fmt"
 	"os"
 	"slices"
 	"testing"
@@ -25,7 +24,7 @@ type testCfgFile struct {
 	testName string
 	path     string
 	link     string
-	err      error
+	errMsg   string
 }
 
 func TestParsePassword(t *testing.T) {
@@ -47,37 +46,37 @@ func TestReadConfigFile(t *testing.T) {
 			"Valid config file - success",
 			"../../testing/fixtures/validator/valid.ini",
 			"",
-			nil,
+			"",
 		},
 		{
 			"Valid config file link - success",
 			"",
 			"../../testing/fixtures/validator/valid.ini",
-			nil,
+			"",
 		},
 		{
 			"Invalid config file - failure",
 			"../../testing/fixtures/validator/invalid.ini",
 			"",
-			fmt.Errorf("Missing param Url or Token"),
+			"Missing param Url or Token",
 		},
 		{
 			"Invalid 2 config file - failure",
 			"../../testing/fixtures/validator/invalid2.ini",
 			"",
-			fmt.Errorf("key-value delimiter not found: UsernameSuffix\n"),
+			"key-value delimiter not found: UsernameSuffix\n",
 		},
 		{
 			"Missing config file - failure",
 			"MISSING",
 			"",
-			fmt.Errorf("No ini file found"),
+			"No ini file found",
 		},
 		{
 			"Config file is a dir - failure",
 			"../../testing/fixtures/validator/",
 			"",
-			fmt.Errorf("No ini file found"),
+			"No ini file found",
 		},
 	}
 
@@ -92,10 +91,12 @@ func TestReadConfigFile(t *testing.T) {
 			if test.path == "" {
 				_ = os.Remove("api.ini")
 			}
-			if test.err == nil {
-				assert.Nil(t, err)
+			if test.errMsg == "" {
+				assert.NoError(t, err)
 			} else {
-				assert.Equal(t, test.err.Error(), err.Error())
+				if assert.Error(t, err) {
+					assert.EqualError(t, err, test.errMsg)
+				}
 			}
 		})
 	}
@@ -107,25 +108,25 @@ func TestLoadPinset(t *testing.T) {
 			"Valid pinset file - success",
 			"../../testing/fixtures/validator/valid.cfg",
 			"",
-			nil,
+			"",
 		},
 		{
 			"Valid pinset link - success",
 			"",
 			"../../testing/fixtures/validator/valid.cfg",
-			nil,
+			"",
 		},
 		{
 			"Missing pinset file - failure",
 			"MISSING",
 			"",
-			fmt.Errorf("No pinset file found"),
+			"No pinset file found",
 		},
 		{
 			"Pinset file is a dir - failure",
 			"../../testing/fixtures/validator/",
 			"",
-			fmt.Errorf("No pinset file found"),
+			"No pinset file found",
 		},
 	}
 
@@ -141,11 +142,13 @@ func TestLoadPinset(t *testing.T) {
 			if test.path == "" {
 				_ = os.Remove("pinset.cfg")
 			}
-			if test.err == nil {
-				assert.Nil(t, err)
+			if test.errMsg == "" {
+				assert.NoError(t, err)
 				assert.True(t, slices.Contains(v.api.ApiConfig.AssertPin, pin))
 			} else {
-				assert.Equal(t, test.err.Error(), err.Error())
+				if assert.Error(t, err) {
+					assert.EqualError(t, err, test.errMsg)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### What does this PR do?

- use sentinel errors when possible
- fix: do not print authRes.Result when it's empty
- dedup JSON api response processing

### Motivation

Offer better readability for the OktaAuthApi package

### More

- [X] Added/updated tests
- [X] Added/updated documentation
