### PR TITLE
Simplify Okta Auth error handling using wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/algolia/openvpn-auth-okta.svg)
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/algolia/openvpn-auth-okta.v2.svg)](https://pkg.go.dev/gopkg.in/algolia/openvpn-auth-okta.v2)
 ![CI status](https://circleci.com/gh/algolia/openvpn-auth-okta/tree/v2.svg?style=shield)
-![Coverage](https://img.shields.io/badge/Coverage-97.5%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-97.2%25-brightgreen)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/algolia/openvpn-auth-okta.v2)](https://goreportcard.com/report/gopkg.in/algolia/openvpn-auth-okta.v2)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/66b5143777dc441993ebfcea172e0626)](https://app.codacy.com/gh/algolia/openvpn-auth-okta/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 

--- a/pkg/oktaApiAuth/api_types.go
+++ b/pkg/oktaApiAuth/api_types.go
@@ -13,7 +13,6 @@ package oktaApiAuth
 import "errors"
 
 var (
-	errContinue        = errors.New("continue")
 	errPushFailed      = errors.New("Push MFA failed")
 	errTOTPFailed      = errors.New("TOTP MFA failed")
 	errMFAUnavailable  = errors.New("No MFA factor available")

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -71,7 +71,7 @@ func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, 
 		}
 
 		var mfaErr error
-		if authRes.Status != "" {
+		if authRes.Result != "" {
 			mfaErr = fmt.Errorf("%s %s MFA authentication failed: %s, %w",
 				factor.Provider,
 				factorType,


### PR DESCRIPTION
### What does this PR do?

Simplify the Okta Auth errar handling that depends on the fact that the current factor
we test is the last one in the list: introduce `parseOktaError` to check for that.
Rename `processJSONAnswer` to `parseAuthResponse` for clarity
