### PR TITLE
Improve Okta user agent compatibility and push factor debugging

### DIFF
--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -298,6 +298,7 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 		if err != nil {
 			return authRes, err
 		}
+		log.Debug().Msgf("waiForPush Okta response: %+v", authRes)
 	}
 	return authRes, nil
 }

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -113,12 +113,17 @@ func (auth *OktaApiAuth) oktaReq(method string, path string, data map[string]str
 	u, _ := url.ParseRequestURI(auth.ApiConfig.Url)
 	u.Path = fmt.Sprintf("/api/v1%s", path)
 
+	userAgent := "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 (OktaOpenVPN)"
 	ssws := fmt.Sprintf("SSWS %s", auth.ApiConfig.Token)
+
 	headers := map[string]string{
-		"User-Agent":    auth.userAgent,
-		"Content-Type":  "application/json",
-		"Accept":        "application/json",
-		"Authorization": ssws,
+		"User-Agent":         userAgent,
+		"Sec-Ch-Ua":          `"Chromium";v="119", "Not?A_Brand";v="24"`,
+		"Sec-Ch-Ua-Platform": `"Linux"`,
+		"Sec-Ch-Ua-Mobile":   "?0",
+		"Content-Type":       "application/json",
+		"Accept":             "application/json",
+		"Authorization":      ssws,
 	}
 	if auth.UserConfig.ClientIp != "" {
 		headers["X-Forwarded-For"] = auth.UserConfig.ClientIp

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -45,7 +45,11 @@ func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, 
 		if err != nil {
 			return err
 		}
-		log.Debug().Msgf("%s %s MFA, Result: %s", factor.Provider, factorType, authRes.Result)
+		log.Debug().Msgf("%s %s MFA (%s), Result: %s",
+			factor.Provider,
+			factorType,
+			factor.Id,
+			authRes.Result)
 
 		if factorType == "Push" {
 			if authRes.Result != "WAITING" {

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -30,7 +30,6 @@ func New() *OktaApiAuth {
 			TOTPFallbackToPush:  false,
 		},
 		UserConfig: &OktaUserConfig{},
-		userAgent:  "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/122.0 (OktaOpenVPN)",
 	}
 }
 

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -116,7 +116,6 @@ func commonAuthTest(authTests []authTest, t *testing.T) {
 			a := &OktaApiAuth{
 				ApiConfig:  apiCfg,
 				UserConfig: userCfg,
-				userAgent:  "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/122.0 (OktaOpenVPN)",
 			}
 			err := a.InitPool()
 			assert.Nil(t, err)

--- a/pkg/oktaApiAuth/types.go
+++ b/pkg/oktaApiAuth/types.go
@@ -61,5 +61,4 @@ type OktaApiAuth struct {
 	ApiConfig  *OktaAPIConfig
 	UserConfig *OktaUserConfig
 	pool       *http.Client
-	userAgent  string
 }


### PR DESCRIPTION
### What does this PR do?

- Use Chrome on Linux user agent along with Sec-CH headers to maximise Okta API "compatibility"
- Improve Push factor debugging by adding its id and a debug output to the waiting loop
