### PR TITLE
feat(ci): add an OBS workflow to trigger build on tag push

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,10 @@
+trigger_build:
+  steps:
+    - trigger_services:
+        project: home:Algolia:OSS
+        package: openvpn-auth-okta
+  filters:
+    event: tag_push
+    branches:
+      only:
+        - master


### PR DESCRIPTION
### What does this PR do?

Add an OBS worklow to be used by the OBS webhook that will trigger the service in order to build package in OBS at https://build.opensuse.org/package/show/home:Algolia:OSS/openvpn-auth-okta

### Additional Notes

See https://openbuildservice.org/help/manuals/obs-user-guide/cha.obs.scm_ci_workflow_integration
