### PR TITLE
set go version to 1.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  coverage-reporter: codacy/coverage-reporter@13.16.7
+  coverage-reporter: codacy/coverage-reporter@14.0.2
 
 executors:
   golang:
     docker:
-      - image: cimg/go:1.22
+      - image: cimg/go:1.23
   codacy:
     docker:
       - image: cimg/openjdk:8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             fi
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
       - run:
           name: GolangCI Lint
           command: golangci-lint run

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Choose the proper instructions for your Linux distribution [here](https://softwa
 Build requirements:
 
 - gcc
-- golang (>= 1.22)
+- golang (>= 1.23)
 - make
 
 If you have a default OpenVPN setup, where plugins are stored in `/usr/lib/openvpn/plugins` and configuration files are stored in `/etc/okta-auth-validator`, then you can use the `make install` command to install the Okta OpenVPN plugin:
@@ -66,7 +66,7 @@ sudo make install
 Build requirements:
 
 - gcc
-- golang (>= 1.22)
+- golang (>= 1.23)
 - make
 
 Compile the plugin from this directory using this command:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Choose the proper instructions for your Linux distribution [here](https://softwa
 Build requirements:
 
 - gcc
-- golang (>= 1.21)
+- golang (>= 1.22)
 - make
 
 If you have a default OpenVPN setup, where plugins are stored in `/usr/lib/openvpn/plugins` and configuration files are stored in `/etc/okta-auth-validator`, then you can use the `make install` command to install the Okta OpenVPN plugin:
@@ -66,7 +66,7 @@ sudo make install
 Build requirements:
 
 - gcc
-- golang (>= 1.21)
+- golang (>= 1.22)
 - make
 
 Compile the plugin from this directory using this command:

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -8,7 +8,7 @@ DEBTRANSFORM-TAR: openvpn-auth-okta-2.8.4.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10
-Build-Depends: debhelper, make, gcc, golang-1.22
+Build-Depends: debhelper, make, gcc, golang-1.23
 Package-List:
  openvpn-auth-okta deb base optional arch=any
  okta-auth-validator deb base optional arch=any

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -9,7 +9,7 @@ Source0: %{name}-%{version}.tar.xz
 Source1: vendor.tar.gz
 Source99: %{name}.rpmlintrc
 
-BuildRequires: golang-1.22
+BuildRequires: golang-1.23
 BuildRequires: gcc
 BuildRequires: make
 Requires: libokta-auth-validator = %{version}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/algolia/openvpn-auth-okta.v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-playground/validator/v10 v10.23.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/algolia/openvpn-auth-okta.v2
 
-go 1.22
+go 1.23
 
 require (
 	github.com/go-playground/validator/v10 v10.23.0


### PR DESCRIPTION
### What does this PR do?

Set go version to 1.23

### Motivation

Ensure we're not impacted by:
- [CVE-2023-39318](https://www.cve.org/CVERecord?id=CVE-2023-39318)
- [CVE-2023-39319](https://www.cve.org/CVERecord?id=CVE-2023-39319)

### More

- [ ] Added/updated tests
- [X] Added/updated documentation
