### PR TITLE
Use go:linkname to access private getPool function from validator tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.23
+      - image: cimg/go:1.24
   codacy:
     docker:
       - image: cimg/openjdk:8.0
@@ -35,7 +35,7 @@ jobs:
             fi
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.62.2
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
       - run:
           name: GolangCI Lint
           command: golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module gopkg.in/algolia/openvpn-auth-okta.v2
 
-go 1.23
+go 1.24.1
+
 require (
 	github.com/go-playground/validator/v10 v10.25.0
 	github.com/google/uuid v1.6.0

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -103,8 +103,8 @@ func (auth *OktaApiAuth) InitPool() error {
 }
 
 // only used by validator_test.go
-// TODO: find a clean way to only export this for tests
-func (auth *OktaApiAuth) Pool() *http.Client {
+// nolint:unused
+func (auth *OktaApiAuth) getPool() *http.Client {
 	return auth.pool
 }
 
@@ -274,10 +274,9 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, stateToken string, f
 // keep retrying the Push MFA (we are waiting here that the user either accept or reject auth)
 func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int, stateToken string) (authRes AuthResponse, err error) {
 	log.Trace().Msgf("oktaApiAuth.waitForPush() %s %s", factor.Type, factor.Provider)
-	checkCount := 0
-	for checkCount == 0 || authRes.Result == "WAITING" {
-		checkCount++
-		if checkCount > auth.ApiConfig.MFAPushMaxRetries {
+
+	for checkCount := 0; checkCount == 0 || authRes.Result == "WAITING"; checkCount++ {
+		if checkCount >= auth.ApiConfig.MFAPushMaxRetries {
 			return AuthResponse{}, fmt.Errorf("%s %w", factor.Provider, errors.New("Push MFA timeout"))
 		}
 

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -16,8 +16,10 @@ import (
 	"net/http"
 	"os"
 	"testing"
+	_ "unsafe"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/algolia/openvpn-auth-okta.v2/pkg/oktaApiAuth"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -68,6 +70,9 @@ type testAuthenticate struct {
 	ret         bool
 	errMsg      string
 }
+
+//go:linkname getPool gopkg.in/algolia/openvpn-auth-okta.v2/pkg/oktaApiAuth.(*OktaApiAuth).getPool
+func getPool(*oktaApiAuth.OktaApiAuth) *http.Client
 
 func TestAuthenticate(t *testing.T) {
 	defer gock.Off()
@@ -150,7 +155,7 @@ func TestAuthenticate(t *testing.T) {
 			assert.True(t, ret)
 			v.usernameTrusted = test.userTrusted
 			v.api.ApiConfig.MFARequired = false
-			gock.InterceptClient(v.api.Pool())
+			gock.InterceptClient(getPool(v.api))
 			gock.DisableNetworking()
 			err := v.Authenticate()
 			assert.Equal(t, test.ret, v.isUserValid)


### PR DESCRIPTION
### What does this PR do?

- use linkname to access OktaApiAuth pool in validator tests
- clean the waitForPush main loop by refactoring the `for` syntax
- bump go to 1.24.1 

### Motivation

Do not export symbol only for test, have a cleaner code

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

See [Accessing Private Functions, Methods, Types and Variables in Go](https://medium.com/@yardenlaif/accessing-private-functions-methods-types-and-variables-in-go-951acccc05a6) for `go:linkname` examples.
