### PR TITLE
Add a PasscodeSeparator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Go version](https://img.shields.io/github/go-mod/go-version/algolia/openvpn-auth-okta.svg)
 [![Go Reference](https://pkg.go.dev/badge/gopkg.in/algolia/openvpn-auth-okta.v2.svg)](https://pkg.go.dev/gopkg.in/algolia/openvpn-auth-okta.v2)
 ![CI status](https://circleci.com/gh/algolia/openvpn-auth-okta/tree/v2.svg?style=shield)
-![Coverage](https://img.shields.io/badge/Coverage-97.2%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-97.3%25-brightgreen)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/algolia/openvpn-auth-okta.v2)](https://goreportcard.com/report/gopkg.in/algolia/openvpn-auth-okta.v2)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/66b5143777dc441993ebfcea172e0626)](https://app.codacy.com/gh/algolia/openvpn-auth-okta/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 

--- a/config/api.ini.inc
+++ b/config/api.ini.inc
@@ -48,3 +48,7 @@ Token:
 # If a passcode is provided and TOTP MFA fails, try Push MFA
 ## (Optional, default: False)
 TOTPFallbackToPush: False
+
+# Character used to separate VPN password from TOTP (passcode)
+## (Optional, default: "")
+PasscodeSeparator:

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -28,6 +28,7 @@ func New() *OktaApiAuth {
 			MFAPushDelaySeconds: 3,
 			AllowedGroups:       "",
 			TOTPFallbackToPush:  false,
+			PasscodeSeparator:   "",
 		},
 		UserConfig: &OktaUserConfig{},
 	}

--- a/pkg/oktaApiAuth/types.go
+++ b/pkg/oktaApiAuth/types.go
@@ -47,6 +47,9 @@ type OktaAPIConfig struct {
 
 	// If a passcode is provided and TOTP MFA fails, try Push MFA
 	TOTPFallbackToPush bool // default: false
+
+	// Character used as separator between VPN password and Okta passcode
+	PasscodeSeparator string
 }
 
 // User credentials and informations

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -12,9 +12,10 @@ package validator
 
 import (
 	"errors"
-	"gopkg.in/ini.v1"
 	"os"
 	"strings"
+
+	"gopkg.in/ini.v1"
 
 	"github.com/phuslu/log"
 )
@@ -83,6 +84,11 @@ func (validator *OktaOpenVPNValidator) readConfigFile() error {
 			log.Error().Msgf("Missing Url or Token parameter in \"%s\"",
 				cfgFile)
 			return errors.New("Missing param Url or Token")
+		}
+		if len(apiConfig.PasscodeSeparator) > 1 {
+			log.Error().Msgf("Invalid passcode separator in \"%s\", it should be empty or 1 character long",
+				cfgFile)
+			return errors.New("Invalid passcode separator")
 		}
 		validator.configFile = cfgFile
 		return nil

--- a/pkg/validator/config_test.go
+++ b/pkg/validator/config_test.go
@@ -27,19 +27,6 @@ type testCfgFile struct {
 	errMsg   string
 }
 
-func TestParsePassword(t *testing.T) {
-	t.Run("Parse password with passcode", func(t *testing.T) {
-		setEnv(setupEnv)
-		v := New()
-		_ = v.loadEnvVars(nil)
-		v.api.UserConfig.Password = "password123456"
-		unsetEnv(setupEnv)
-		v.parsePassword()
-		assert.Equal(t, "password", v.api.UserConfig.Password)
-		assert.Equal(t, "123456", v.api.UserConfig.Passcode)
-	})
-}
-
 func TestReadConfigFile(t *testing.T) {
 	tests := []testCfgFile{
 		{

--- a/pkg/validator/config_test.go
+++ b/pkg/validator/config_test.go
@@ -54,6 +54,12 @@ func TestReadConfigFile(t *testing.T) {
 			"key-value delimiter not found: UsernameSuffix\n",
 		},
 		{
+			"Invalid separator in config file - failure",
+			"../../testing/fixtures/validator/invalid_separator.ini",
+			"",
+			"Invalid passcode separator",
+		},
+		{
 			"Missing config file - failure",
 			"MISSING",
 			"",

--- a/pkg/validator/utils.go
+++ b/pkg/validator/utils.go
@@ -29,18 +29,27 @@ const passcodeLen int = 6
 // Parse the password looking for an TOTP
 func (validator *OktaOpenVPNValidator) parsePassword() {
 	log.Trace().Msg("validator.parsePassword()")
+	separator := validator.api.ApiConfig.PasscodeSeparator
 	// If the password provided by the user is longer than a OTP (6 cars)
 	// and the last 6 caracters are digits
 	// then extract the user password (first) and the OTP
 	userConfig := validator.api.UserConfig
-	if len(userConfig.Password) > passcodeLen {
-		last := userConfig.Password[len(userConfig.Password)-passcodeLen:]
-		if _, err := strconv.Atoi(last); err == nil {
-			userConfig.Passcode = last
-			userConfig.Password = userConfig.Password[:len(userConfig.Password)-passcodeLen]
+
+	r, _ := regexp.Compile("[0-9]{" + strconv.Itoa(passcodeLen) + "}$")
+	idx := r.FindStringIndex(userConfig.Password)
+
+	if idx != nil {
+		if len(separator) == 1 && idx[0]-1 > 0 && userConfig.Password[idx[0]-1] == separator[0] {
+			userConfig.Passcode = userConfig.Password[idx[0]:]
+			userConfig.Password = userConfig.Password[0 : idx[0]-1]
+		} else if len(separator) == 0 {
+			userConfig.Passcode = userConfig.Password[idx[0]:]
+			userConfig.Password = userConfig.Password[0:idx[0]]
 		} else {
 			log.Debug().Msgf("no TOTP found in password")
 		}
+	} else {
+		log.Debug().Msgf("no TOTP found in password")
 	}
 }
 

--- a/pkg/validator/utils_test.go
+++ b/pkg/validator/utils_test.go
@@ -32,6 +32,64 @@ type testControlFile struct {
 	errMsg   string
 }
 
+type testParse struct {
+	testName          string
+	password          string
+	separator         string
+	expected_password string
+	expected_passcode string
+}
+
+func TestParsePassword(t *testing.T) {
+	tests := []testParse{
+		{
+			"TOTP - empty separator",
+			"toto0123456",
+			"",
+			"toto0",
+			"123456",
+		},
+		{
+			"TOTP - non empty separator",
+			"toto0|123456",
+			"|",
+			"toto0",
+			"123456",
+		},
+		{
+			"no TOTP - empty separator",
+			"toto12345",
+			"",
+			"toto12345",
+			"",
+		},
+		{
+			"no TOTP - non empty separator",
+			"toto12345",
+			"|",
+			"toto12345",
+			"",
+		},
+		{
+			"no TOTP - misplaced non empty separator",
+			"tot|o123456",
+			"|",
+			"tot|o123456",
+			"",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			v := New()
+			v.api.ApiConfig.PasscodeSeparator = test.separator
+			v.api.UserConfig.Password = test.password
+			v.parsePassword()
+			assert.Equal(t, test.expected_password, v.api.UserConfig.Password)
+			assert.Equal(t, test.expected_passcode, v.api.UserConfig.Passcode)
+		})
+	}
+}
+
 func TestCheckUsernameFormat(t *testing.T) {
 	tests := []usernameTest{
 		{

--- a/testing/fixtures/validator/invalid_separator.ini
+++ b/testing/fixtures/validator/invalid_separator.ini
@@ -1,0 +1,8 @@
+[OktaAPI]
+Url: https://example.oktapreview.com
+Token: 12345
+UsernameSuffix: example.com
+AllowUntrustedUsers: True
+MFARequired: True
+MFAPushDelaySeconds: 2
+PasscodeSeparator: ||


### PR DESCRIPTION
### What does this PR do?

Add a new option to setup a separator character between VPN password and TOTP.

### Motivation

@DXC-Kevin-Huang reported an issue he has with VPN password where policy enforce usage of a sequence of digit that matches
the pattern we had to detect TOTP.

### More

- [X] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

See https://github.com/algolia/openvpn-auth-okta/issues/91
