### PR TITLE
Bump to version 2.9.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+openvpn-auth-okta (2.9.0) stable; urgency=medium
+
+  [ Jeremy JACQUE ]
+  * chore(doc): update list of available distro / arch
+  * feat: add an potion to configure a separator between the VPN password and the TOTP passcode
+  * chore(validator): ensure the separator length is 1 - a character
+  * clean(validator/test): the TestParsePassword func has been move to utils test
+  * chore: add missing test for separator validity in ini file
+
+  [ dependabot[bot] ]
+  * chore(deps): bump github.com/go-playground/validator/v10
+  * chore(deps): bump github.com/phuslu/log from 1.0.117 to 1.0.119
+
+ -- Jeremy JACQUE <jeremy.jacque@algolia.com>  Tue, 19 Aug 2025 14:03:31 +0200
+
 openvpn-auth-okta (2.8.6) stable; urgency=medium
 
   [ dependabot[bot] ]

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -3,8 +3,8 @@ DEBTRANSFORM-RELEASE: 1
 Source: openvpn-auth-okta
 Binary: openvpn-auth-okta
 Architecture: any
-Version: 2.8.6
-DEBTRANSFORM-TAR: openvpn-auth-okta-2.8.6.tar.xz
+Version: 2.9.0
+DEBTRANSFORM-TAR: openvpn-auth-okta-2.9.0.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -1,5 +1,5 @@
 Name: openvpn-auth-okta
-Version: 2.8.6
+Version: 2.9.0
 Release: 1%{?dist}
 Summary: Go programming language
 Group: Productivity/Networking/Security
@@ -86,6 +86,16 @@ make DESTDIR=%{buildroot} LIB_PREFIX=%{_libdir} install
 
 
 %changelog
+* Tue Aug 19 2025 Jeremy JACQUE <jeremy.jacque@algolia.com> - 2.9.0-1
+- chore(deps): bump go dep to 1.24 for packaging
+- chore(doc): update list of available distro / arch
+- chore(deps): bump github.com/go-playground/validator/v10
+- chore(deps): bump github.com/phuslu/log from 1.0.117 to 1.0.119
+- feat: add an option to configure a separator between the VPN password and the TOTP passcode
+- chore(validator): ensure the separator length is 1 - a character
+- clean(validator/test): the TestParsePassword func has been move to utils test
+- chore: add missing test for separator validity in ini file
+
 * Wed Apr 30 2025 Jeremy JACQUE <jeremy.jacque@algolia.com> - 2.8.6-1
 - chore(deps): bump github.com/go-playground/validator/v10
 - chore(deps): bump golang.org/x/net from 0.34.0 to 0.36.0


### PR DESCRIPTION
### What does this PR do?

Bump version to 2.9.0

### Motivation

Release various updates / fixes.
Includes https://github.com/algolia/openvpn-auth-okta/pull/93

### More

- [ ] Added/updated tests
- [ ] Added/updated documentation

### Additional Notes

Release possible fix for https://github.com/algolia/openvpn-auth-okta/issues/91
