### PR TITLE
Fix missing C XOPEN_SOURCE and display license in README

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.24
+      - image: cimg/go:1.25
   codacy:
     docker:
       - image: cimg/openjdk:8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             fi
       - run:
           name: Install golangci-lint
-          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+          command: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.6.2
       - run:
           name: GolangCI Lint
           command: golangci-lint run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  coverage-reporter: codacy/coverage-reporter@14.0.2
+  coverage-reporter: codacy/coverage-reporter@14.1.0
 
 executors:
   golang:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endif
 INSTALL := install
 CC := gcc
 INC := -I. -I./build
-CFLAGS := -fPIC $(INC) -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+CFLAGS := -fPIC $(INC) -O2 -D_FORTIFY_SOURCE=2 -D_XOPEN_SOURCE=700 -fstack-protector-strong
 LDFLAGS := -shared -fPIC
 
 DESTDIR :=

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Coverage](https://img.shields.io/badge/Coverage-97.3%25-brightgreen)
 [![Go Report Card](https://goreportcard.com/badge/gopkg.in/algolia/openvpn-auth-okta.v2)](https://goreportcard.com/report/gopkg.in/algolia/openvpn-auth-okta.v2)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/66b5143777dc441993ebfcea172e0626)](https://app.codacy.com/gh/algolia/openvpn-auth-okta/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
 
 # Introduction
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: openvpn-auth-okta
 Section: net
 Priority: optional
 Maintainer: Jeremy Jacque <jeremy.jacque@algolia.com>
-Build-Depends: debhelper (>=10), make, gcc, golang-1.24
+Build-Depends: debhelper (>=10), make, gcc, golang-1.25
 Standards-Version: 0.1
 Homepage: https://github.com/algolia/openvpn-auth-okta
 

--- a/dist/openvpn-auth-okta.dsc
+++ b/dist/openvpn-auth-okta.dsc
@@ -8,7 +8,7 @@ DEBTRANSFORM-TAR: openvpn-auth-okta-2.9.0.tar.xz
 Maintainer: Foundation Squad <foundation@algolia.com>
 Homepage: https://github.com/algolia/openvpn-auth-okta
 Standards-Version: 4.5.10
-Build-Depends: debhelper, make, gcc, golang-1.24
+Build-Depends: debhelper, make, gcc, golang-1.25
 Package-List:
  openvpn-auth-okta deb base optional arch=any
  okta-auth-validator deb base optional arch=any

--- a/dist/openvpn-auth-okta.spec
+++ b/dist/openvpn-auth-okta.spec
@@ -9,7 +9,7 @@ Source0: %{name}-%{version}.tar.xz
 Source1: vendor.tar.gz
 Source99: %{name}.rpmlintrc
 
-BuildRequires: golang-1.24
+BuildRequires: golang-1.25
 BuildRequires: gcc
 BuildRequires: make
 Requires: libokta-auth-validator = %{version}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gopkg.in/algolia/openvpn-auth-okta.v2
 
-go 1.24.1
+go 1.25.4
 
 require (
 	github.com/go-playground/validator/v10 v10.28.0

--- a/pkg/oktaApiAuth/api.go
+++ b/pkg/oktaApiAuth/api.go
@@ -48,7 +48,7 @@ func (auth *OktaApiAuth) InitPool() error {
 			log.Error().Msgf("Error in Dial: %s", err)
 			return err
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }()
 		certs := conn.ConnectionState().PeerCertificates
 		for _, cert := range certs {
 			if !cert.IsCA {
@@ -66,7 +66,7 @@ func (auth *OktaApiAuth) InitPool() error {
 						"a TLS public key pinning check.",
 						"Update your \"pinset.cfg\" file or ",
 						"contact support@okta.com with this error message")
-					return errors.New("Server pubkey does not match pinned keys")
+					return errors.New("server pubkey does not match pinned keys")
 				}
 			}
 		}
@@ -153,7 +153,7 @@ func (auth *OktaApiAuth) oktaReq(method string, path string, data map[string]str
 	if err != nil {
 		return 0, nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	jsonBody, err = io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error().Msgf("Error reading Okta API response: %s", err)
@@ -203,13 +203,13 @@ func parseAuthResponse(apiRes []byte) (AuthResponse, error) {
 	var authRes AuthResponse
 	err := json.Unmarshal(apiRes, &authRes)
 	if err != nil {
-		return AuthResponse{}, fmt.Errorf("Error unmarshaling Okta API response: %w", err)
+		return AuthResponse{}, fmt.Errorf("error unmarshaling Okta API response: %w", err)
 	}
 
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	err = validate.Struct(authRes)
 	if err != nil {
-		return AuthResponse{}, fmt.Errorf("Error unmarshaling Okta API response: %w", err)
+		return AuthResponse{}, fmt.Errorf("error unmarshaling Okta API response: %w", err)
 	}
 	return authRes, nil
 }
@@ -237,7 +237,7 @@ func (auth *OktaApiAuth) doAuthFirstStep(factor AuthFactor, stateToken string, f
 	log.Trace().Msgf("oktaApiAuth.doAuthFirstStep() %s %s", factor.Type, factor.Provider)
 	code, apiRes, err := auth.doAuth(factor.Id, stateToken)
 	if err != nil {
-		return AuthResponse{}, fmt.Errorf("Okta Authentication request error: %w", err)
+		return AuthResponse{}, fmt.Errorf("okta authentication request error: %w", err)
 	}
 
 	validate := validator.New(validator.WithRequiredStructEnabled())
@@ -277,20 +277,20 @@ func (auth *OktaApiAuth) waitForPush(factor AuthFactor, count int, nbFactors int
 
 	for checkCount := 0; checkCount == 0 || authRes.Result == "WAITING"; checkCount++ {
 		if checkCount >= auth.ApiConfig.MFAPushMaxRetries {
-			return AuthResponse{}, fmt.Errorf("%s %w", factor.Provider, errors.New("Push MFA timeout"))
+			return AuthResponse{}, fmt.Errorf("%s %w", factor.Provider, errors.New("push MFA timeout"))
 		}
 
 		time.Sleep(time.Duration(auth.ApiConfig.MFAPushDelaySeconds) * time.Second)
 
 		code, apiRes, err := auth.doAuth(factor.Id, stateToken)
 		if err != nil {
-			return AuthResponse{}, fmt.Errorf("Okta Authentication request error: %w", err)
+			return AuthResponse{}, fmt.Errorf("okta authentication request error: %w", err)
 		}
 		if code != 200 && code != 202 {
 			return AuthResponse{}, fmt.Errorf("%s push MFA invalid HTTP status code %d, %w",
 				factor.Provider,
 				code,
-				errors.New("Push MFA failed"))
+				errors.New("push MFA failed"))
 		}
 
 		authRes, err = parseAuthResponse(apiRes)

--- a/pkg/oktaApiAuth/api_test.go
+++ b/pkg/oktaApiAuth/api_test.go
@@ -86,7 +86,7 @@ func TestInitPool(t *testing.T) {
 			tlsHost,
 			tlsPort,
 			[]string{invalidPinset},
-			"Server pubkey does not match pinned keys",
+			"server pubkey does not match pinned keys",
 		},
 
 		{

--- a/pkg/oktaApiAuth/api_types.go
+++ b/pkg/oktaApiAuth/api_types.go
@@ -13,13 +13,13 @@ package oktaApiAuth
 import "errors"
 
 var (
-	errPushFailed      = errors.New("Push MFA failed")
+	errPushFailed      = errors.New("push MFA failed")
 	errTOTPFailed      = errors.New("TOTP MFA failed")
-	errMFAUnavailable  = errors.New("No MFA factor available")
+	errMFAUnavailable  = errors.New("no MFA factor available")
 	errMFARequired     = errors.New("MFA required")
-	errUserLocked      = errors.New("User locked out")
-	errPasswordExpired = errors.New("User password expired")
-	errEnrollNeeded    = errors.New("Needs to enroll")
+	errUserLocked      = errors.New("user locked out")
+	errPasswordExpired = errors.New("user password expired")
+	errEnrollNeeded    = errors.New("needs to enroll")
 )
 
 type ErrorResponse struct {

--- a/pkg/oktaApiAuth/oktaApiAuth.go
+++ b/pkg/oktaApiAuth/oktaApiAuth.go
@@ -39,6 +39,10 @@ func New() *OktaApiAuth {
 func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, factorType string) (err error) {
 	log.Trace().Msgf("oktaApiAuth.verifyFactors() %s", factorType)
 	nbFactors := len(factors)
+	ftype := factorType
+	if factorType == "Push" {
+		ftype = "push"
+	}
 	for count, factor := range factors {
 		log.Debug().Msgf("verifying %s factor nb %d", factorType, count)
 		authRes, err := auth.doAuthFirstStep(factor, stateToken, factorType)
@@ -80,12 +84,12 @@ func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, 
 				factor.Provider,
 				factorType,
 				authRes.Result,
-				fmt.Errorf("%s MFA failed", factorType))
+				fmt.Errorf("%s MFA failed", ftype))
 		} else {
 			mfaErr = fmt.Errorf("%s %s MFA authentication failed, %w",
 				factor.Provider,
 				factorType,
-				fmt.Errorf("%s MFA failed", factorType))
+				fmt.Errorf("%s MFA failed", ftype))
 		}
 
 		err = parseOktaError(mfaErr, count, nbFactors)
@@ -95,7 +99,7 @@ func (auth *OktaApiAuth) verifyFactors(stateToken string, factors []AuthFactor, 
 	}
 	// Reached only when the list of factors provided is empty
 	log.Debug().Msgf("No %s MFA available", factorType)
-	return fmt.Errorf("No %s MFA available", factorType)
+	return fmt.Errorf("no %s MFA available", ftype)
 }
 
 // Gather the list of factors available from the pre authentication api response,
@@ -113,7 +117,7 @@ func (auth *OktaApiAuth) validateUserMFA(preAuthRes PreAuthResponse) (err error)
 				// try Push MFA authentication
 				goto PUSH
 			}
-			if err.Error() != "No TOTP MFA available" {
+			if err.Error() != "no TOTP MFA available" {
 				auth.cancelAuth(preAuthRes.Token)
 				return err
 			}
@@ -124,7 +128,7 @@ func (auth *OktaApiAuth) validateUserMFA(preAuthRes PreAuthResponse) (err error)
 
 PUSH:
 	if err = auth.verifyFactors(preAuthRes.Token, factorsPush, "Push"); err != nil {
-		if err.Error() != "No Push MFA available" {
+		if err.Error() != "no push MFA available" {
 			auth.cancelAuth(preAuthRes.Token)
 			return err
 		}
@@ -183,6 +187,6 @@ func (auth *OktaApiAuth) Auth() error {
 		if preAuthRes.Token != "" {
 			auth.cancelAuth(preAuthRes.Token)
 		}
-		return errors.New("Unknown preauth status")
+		return errors.New("unknown preauth status")
 	}
 }

--- a/pkg/oktaApiAuth/oktaApiAuth_test.go
+++ b/pkg/oktaApiAuth/oktaApiAuth_test.go
@@ -162,7 +162,7 @@ func TestAuthGroups(t *testing.T) {
 			"test1, test2",
 			1,
 			false,
-			"Not mmember of an AllowedGroup",
+			"not member of an AllowedGroup",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -394,7 +394,7 @@ func TestAuthPreAuth(t *testing.T) {
 			"",
 			1,
 			false,
-			"Unknown preauth status",
+			"unknown preauth status",
 		},
 	}
 	commonAuthTest(authTests, t)
@@ -825,7 +825,7 @@ func TestAuthPushMFA(t *testing.T) {
 			"",
 			1,
 			false,
-			"Push MFA timeout",
+			"push MFA timeout",
 		},
 
 		{

--- a/pkg/oktaApiAuth/utils.go
+++ b/pkg/oktaApiAuth/utils.go
@@ -54,7 +54,7 @@ func (auth *OktaApiAuth) checkAllowedGroups() error {
 			return errors.New("invalid group list return by API")
 		}
 
-		var aGroups []string = strings.Split(auth.ApiConfig.AllowedGroups, ",")
+		var aGroups = strings.Split(auth.ApiConfig.AllowedGroups, ",")
 		for _, uGroup := range groupRes {
 			gName := uGroup.Profile.Name
 			if slices.Contains(aGroups, gName) {
@@ -62,7 +62,7 @@ func (auth *OktaApiAuth) checkAllowedGroups() error {
 				return nil
 			}
 		}
-		return errors.New("Not mmember of an AllowedGroup")
+		return errors.New("not member of an AllowedGroup")
 	}
 	return nil
 }
@@ -72,13 +72,14 @@ func (auth *OktaApiAuth) checkAllowedGroups() error {
 func (auth *OktaApiAuth) getUserFactors(preAuthRes PreAuthResponse) (factorsTOTP []AuthFactor, factorsPush []AuthFactor) {
 	log.Trace().Msg("oktaApiAuth.getUserFactors()")
 	for _, f := range preAuthRes.Embedded.Factors {
-		if f.Type == "token:software:totp" {
+		switch f.Type {
+		case "token:software:totp":
 			if auth.UserConfig.Passcode != "" {
 				factorsTOTP = append(factorsTOTP, f)
 			}
-		} else if f.Type == "push" {
+		case "push":
 			factorsPush = append(factorsPush, f)
-		} else {
+		default:
 			log.Debug().Msgf("unsupported factortype: %s, skipping", f.Type)
 		}
 	}

--- a/pkg/oktaApiAuth/utils_test.go
+++ b/pkg/oktaApiAuth/utils_test.go
@@ -129,7 +129,7 @@ func TestCheckAllowedGroups(t *testing.T) {
 			},
 			"test1, test2",
 			token,
-			"Not mmember of an AllowedGroup",
+			"not member of an AllowedGroup",
 		},
 	}
 

--- a/pkg/validator/config.go
+++ b/pkg/validator/config.go
@@ -83,18 +83,18 @@ func (validator *OktaOpenVPNValidator) readConfigFile() error {
 		if apiConfig.Url == "" || apiConfig.Token == "" {
 			log.Error().Msgf("Missing Url or Token parameter in \"%s\"",
 				cfgFile)
-			return errors.New("Missing param Url or Token")
+			return errors.New("missing param Url or Token")
 		}
 		if len(apiConfig.PasscodeSeparator) > 1 {
 			log.Error().Msgf("Invalid passcode separator in \"%s\", it should be empty or 1 character long",
 				cfgFile)
-			return errors.New("Invalid passcode separator")
+			return errors.New("invalid passcode separator")
 		}
 		validator.configFile = cfgFile
 		return nil
 	}
 	log.Error().Msgf("No ini file found in %v", cfgPaths)
-	return errors.New("No ini file found")
+	return errors.New("no ini file found")
 }
 
 // Read all allowed pubkey fingerprints for the API server from pinset file
@@ -133,5 +133,5 @@ func (validator *OktaOpenVPNValidator) loadPinset() error {
 		validator.pinsetFile = pinsetFile
 		return nil
 	}
-	return errors.New("No pinset file found")
+	return errors.New("no pinset file found")
 }

--- a/pkg/validator/config_test.go
+++ b/pkg/validator/config_test.go
@@ -45,7 +45,7 @@ func TestReadConfigFile(t *testing.T) {
 			"Invalid config file - failure",
 			"../../testing/fixtures/validator/invalid.ini",
 			"",
-			"Missing param Url or Token",
+			"missing param Url or Token",
 		},
 		{
 			"Invalid 2 config file - failure",
@@ -57,19 +57,19 @@ func TestReadConfigFile(t *testing.T) {
 			"Invalid separator in config file - failure",
 			"../../testing/fixtures/validator/invalid_separator.ini",
 			"",
-			"Invalid passcode separator",
+			"invalid passcode separator",
 		},
 		{
 			"Missing config file - failure",
 			"MISSING",
 			"",
-			"No ini file found",
+			"no ini file found",
 		},
 		{
 			"Config file is a dir - failure",
 			"../../testing/fixtures/validator/",
 			"",
-			"No ini file found",
+			"no ini file found",
 		},
 	}
 
@@ -113,13 +113,13 @@ func TestLoadPinset(t *testing.T) {
 			"Missing pinset file - failure",
 			"MISSING",
 			"",
-			"No pinset file found",
+			"no pinset file found",
 		},
 		{
 			"Pinset file is a dir - failure",
 			"../../testing/fixtures/validator/",
 			"",
-			"No pinset file found",
+			"no pinset file found",
 		},
 	}
 

--- a/pkg/validator/loading.go
+++ b/pkg/validator/loading.go
@@ -60,14 +60,14 @@ func (validator *OktaOpenVPNValidator) loadViaFile(path string) error {
 	viaFileInfos = removeEmptyStrings(viaFileInfos)
 	if len(viaFileInfos) < 2 {
 		log.Error().Msgf("Invalid OpenVPN via-file \"%s\" content", path)
-		return errors.New("Invalid via-file")
+		return errors.New("invalid via-file")
 	}
 	username := viaFileInfos[0]
 	password := viaFileInfos[1]
 
 	if !checkUsernameFormat(username) {
 		log.Error().Msg("Username or CN invalid format")
-		return errors.New("Invalid CN or username format")
+		return errors.New("invalid CN or username format")
 	}
 
 	apiConfig := validator.api.ApiConfig
@@ -111,17 +111,17 @@ func (validator *OktaOpenVPNValidator) loadEnvVars(pluginEnv *PluginEnv) error {
 	// if username is empty, there is an issue somewhere
 	if pluginEnv.Username == "" {
 		log.Error().Msg("No username or CN provided")
-		return errors.New("No CN or username")
+		return errors.New("no CN or username")
 	}
 
 	if pluginEnv.Password == "" {
 		log.Error().Msg("No password provided")
-		return errors.New("No password")
+		return errors.New("no password")
 	}
 
 	if !checkUsernameFormat(pluginEnv.Username) {
 		log.Error().Msg("Username or CN invalid format")
-		return errors.New("Invalid CN or username format")
+		return errors.New("invalid CN or username format")
 	}
 
 	if apiConfig.AllowUntrustedUsers {

--- a/pkg/validator/loading_test.go
+++ b/pkg/validator/loading_test.go
@@ -63,7 +63,7 @@ func TestLoadViaFile(t *testing.T) {
 			"",
 			"dade.murphy",
 			"password",
-			"Invalid via-file",
+			"invalid via-file",
 		},
 		{
 			"Invalid username in via file - failure",
@@ -71,7 +71,7 @@ func TestLoadViaFile(t *testing.T) {
 			"",
 			"dade.murphy*",
 			"password",
-			"Invalid CN or username format",
+			"invalid CN or username format",
 		},
 		{
 			"Missing via file - failure",
@@ -112,13 +112,13 @@ func TestLoadViaFile(t *testing.T) {
 
 func setEnv(e map[string]string) {
 	for k, v := range e {
-		os.Setenv(k, v)
+		_ = os.Setenv(k, v)
 	}
 }
 
 func unsetEnv(e map[string]string) {
 	for k := range e {
-		os.Unsetenv(k)
+		_ = os.Unsetenv(k)
 	}
 }
 
@@ -150,7 +150,7 @@ func TestLoadEnvVars(t *testing.T) {
 				"password":     "",
 				"untrusted_ip": "1.2.3.4",
 			},
-			"No password",
+			"no password",
 		},
 		{
 			"Test username/!allowUntrustedUsers/usernameSuffix - success",
@@ -206,7 +206,7 @@ func TestLoadEnvVars(t *testing.T) {
 				"password":     "password",
 				"untrusted_ip": "1.2.3.4",
 			},
-			"No CN or username",
+			"no CN or username",
 		},
 		{
 			"Test invalid username/common_name - failure",
@@ -220,7 +220,7 @@ func TestLoadEnvVars(t *testing.T) {
 				"password":     "password",
 				"untrusted_ip": "1.2.3.4",
 			},
-			"Invalid CN or username format",
+			"invalid CN or username format",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/validator/utils.go
+++ b/pkg/validator/utils.go
@@ -57,7 +57,7 @@ func (validator *OktaOpenVPNValidator) parsePassword() {
 func (validator *OktaOpenVPNValidator) checkControlFilePerm() error {
 	log.Trace().Msg("validator.checkControlFilePerm()")
 	if validator.controlFile == "" {
-		return errors.New("Unknow control file")
+		return errors.New("unknown control file")
 	}
 
 	if !checkNotWritable(validator.controlFile) {

--- a/pkg/validator/utils_test.go
+++ b/pkg/validator/utils_test.go
@@ -137,7 +137,7 @@ func TestCheckControlFilePerm(t *testing.T) {
 			"Test empty control file path - failure",
 			"",
 			0600,
-			"Unknow control file",
+			"unknown control file",
 		},
 		{
 			"Test valid control file permissions - success",

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -121,11 +121,11 @@ func (validator *OktaOpenVPNValidator) Authenticate() error {
 	log.Trace().Msg("validator.Authenticate()")
 	if !validator.usernameTrusted {
 		log.Warn().Msgf("is not trusted - failing")
-		return errors.New("User not trusted")
+		return errors.New("user not trusted")
 	}
 
 	if err := validator.api.Auth(); err != nil {
-		return errors.New("Authentication failed")
+		return errors.New("authentication failed")
 	}
 
 	validator.isUserValid = true

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -85,7 +85,7 @@ func TestAuthenticate(t *testing.T) {
 			false,
 			nil,
 			false,
-			"User not trusted",
+			"user not trusted",
 		},
 
 		{
@@ -125,7 +125,7 @@ func TestAuthenticate(t *testing.T) {
 				},
 			},
 			false,
-			"Authentication failed",
+			"authentication failed",
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

- Fix `sigaction incomplete type` error with some GCC version by declaring the `XOPEN_SOURCE` C macro to `700` ([POSIX 2017](https://pubs.opengroup.org/onlinepubs/9699919799/))
- Show MPL-2 licensing in README
- update Go to 1.25
- update Codacy Orb
- update `golangci-lint`
  - make the appropriate fixes

### More

- [X] Added/updated tests
- [X] Added/updated documentation
