### PR TITLE
chore: add build optimization and CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  coverage-reporter: codacy/coverage-reporter@14.1.0
+  coverage-reporter: codacy/coverage-reporter@14.1.2
 
 executors:
   golang:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       - image: cimg/openjdk:8.0
 
 jobs:
-  golangci-lint:
+  lint:
     executor: golang
     steps:
       - checkout
@@ -39,6 +39,14 @@ jobs:
       - run:
           name: GolangCI Lint
           command: golangci-lint run
+      - run:
+          name: Install cppcheck
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y cppcheck
+      - run:
+          name: C Lint
+          command: make cpp-lint
       - save_cache: &save-cache
           paths:
             - /home/circleci/go/pkg/mod
@@ -86,10 +94,10 @@ jobs:
 workflows:
   lint_test_build:
     jobs:
-      - golangci-lint
+      - lint
       - test:
           requires:
-            - golangci-lint
+            - lint
       - codacy-coverage:
           requires:
             - test

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,12 @@ $(BUILDDIR)/cover-badge.out: $(BUILDDIR)/cover.out
 # You'll need to install golangci-lint and cppcheck
 # see https://github.com/danmar/cppcheck#packages
 # https://github.com/golangci/golangci-lint#install-golangci-lint
-lint:
+lint: golang-lint cpp-lint
+
+golang-lint:
 	golangci-lint run
+
+cpp-lint:
 	cppcheck $(INC) --enable=all --disable=missingInclude --check-level=exhaustive *.c
 
 install: all

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,17 @@ endif
 INSTALL := install
 CC := gcc
 INC := -I. -I./build
-CFLAGS := -fPIC $(INC) -O2 -D_FORTIFY_SOURCE=2 -D_XOPEN_SOURCE=700 -fstack-protector-strong
-LDFLAGS := -shared -fPIC
+
+SEC_CFLAGS := -D_FORTIFY_SOURCE=2 -fstack-protector-strong -D_GLIBCXX_ASSERTIONS -Wformat -Wformat-security -Werror=format-security
+CFLAGS := -fPIC $(INC) -O3 -D_XOPEN_SOURCE=700 $(SEC_CFLAGS) -fomit-frame-pointer
+LDFLAGS := -shared -fPIC -Wl,-O3 -Wl,--strip-all -Wl,--as-needed
 
 DESTDIR :=
 LIB_PREFIX := /usr/lib
 PLUGIN_DIR := openvpn/plugins
 BUILDDIR := build
 
-GOPLUGIN_LDFLAGS := -ldflags '-s -w -extldflags "-static"'
+GOPLUGIN_LDFLAGS := -ldflags '-s -w -extldflags "-static -O3 -fno-plt -flto=auto"'
 GOPLUGIN_FLAGS := -trimpath -buildmode=pie -a $(GOPLUGIN_LDFLAGS)
 
 ifeq ($(UNAME_S),Linux)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ LIBOKTA_FLAGS := -trimpath -buildmode=c-shared $(LIBOKTA_LDFLAGS)
 PKG_SRC := $(shell ls pkg/*/*.go | grep -v "_test.go")
 PLUGIN_DEPS := $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-auth-okta.o openvpn-plugin.h
 
-
+.PHONY: all
 all: binary plugin
 
 $(BUILDDIR):
@@ -50,6 +50,7 @@ $(BUILDDIR)/%.o: %.c | $(BUILDDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 # Build the plugin as a standalone binary
+.PHONY: binary
 binary: $(BUILDDIR)/okta-auth-validator
 $(BUILDDIR)/okta-auth-validator: cmd/okta-auth-validator/main.go $(PKG_SRC) | $(BUILDDIR)
 	CGO_ENABLED=$(CGO) go build $(GOPLUGIN_FLAGS) -o $(BUILDDIR)/okta-auth-validator cmd/okta-auth-validator/main.go
@@ -63,13 +64,17 @@ $(BUILDDIR)/libokta-auth-validator.so: lib/libokta-auth-validator.go $(PKG_SRC) 
 	go build $(LIBOKTA_FLAGS) -o $(BUILDDIR)/libokta-auth-validator.so lib/libokta-auth-validator.go
 
 # Build all shared libraries
+.PHONY: plugin
 plugin: $(BUILDDIR)/libokta-auth-validator.so $(BUILDDIR)/openvpn-plugin-auth-okta.so
 
+.PHONY: test
 test: $(BUILDDIR)/cover.out
 
+.PHONY: coverage
 coverage: $(BUILDDIR)/coverage.html
 
-# Run gobagde to update the README coverage badge after golang tests
+# Run gobadge to update the README coverage badge after golang tests
+.PHONY: badge
 badge: $(BUILDDIR)/cover-badge.out
 	if [ ! -f /tmp/gobadge ]; then \
 		curl -sf https://gobinaries.com/github.com/AlexBeauchemin/gobadge@v0.3.0 | PREFIX=/tmp sh; \
@@ -94,11 +99,14 @@ $(BUILDDIR)/cover-badge.out: $(BUILDDIR)/cover.out
 # You'll need to install golangci-lint and cppcheck
 # see https://github.com/danmar/cppcheck#packages
 # https://github.com/golangci/golangci-lint#install-golangci-lint
+.PHONY: lint
 lint: golang-lint cpp-lint
 
+.PHONY: golang-lint
 golang-lint:
 	golangci-lint run
 
+.PHONY: cpp-lint
 cpp-lint:
 	cppcheck $(INC) --enable=all --disable=missingInclude --check-level=exhaustive *.c
 
@@ -118,10 +126,9 @@ install: all
 		$(INSTALL) -m640 config/api.ini.inc $(DESTDIR)/etc/okta-auth-validator/api.ini; \
 	fi
 
+.PHONY: clean
 clean:
 	rm -Rf $(BUILDDIR)
 	rm -f testing/fixtures/validator/valid_control_file
 	rm -f testing/fixtures/validator/invalid_control_file
 	rm -f testing/fixtures/validator/control_file
-
-.PHONY: clean binary install lint badge coverage test plugin


### PR DESCRIPTION
## Summary

- Add optimization build flags to the Makefile for both C and Go builds to improve runtime performance
- Enhanced Makefile with security compiler flags (`-D_FORTIFY_SOURCE=2`, `-fstack-protector-strong`, `-Wformat-security`)
- Update coverage-reporter orb in CircleCI config
- Split lint target in Makefile for better organization
- Add multiple .PHONY targets in Makefile for proper dependency tracking
- Add C code check using the cpp-lint make target to CI pipeline

## Test plan

- [ ] Verify the build completes successfully with `make plugin` and `make binary`
- [ ] Verify all lint targets run correctly (`make lint`, `make cpp-lint`)
- [ ] Verify the resulting binaries/libraries work correctly with OpenVPN